### PR TITLE
Feature/i18n

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from 'next';
+import createNextIntlPlugin from 'next-intl/plugin';
 
 const nextConfig: NextConfig = {
 	devIndicators: false,
 };
 
-export default nextConfig;
+const withNextIntl = createNextIntlPlugin();
+export default withNextIntl(nextConfig);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cmdk": "^1.1.1",
     "lucide-react": "^0.511.0",
     "next": "15.3.2",
+    "next-intl": "^4.1.0",
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -29,6 +29,9 @@
             "selection": {
                 "selected": "{count, plural, one {# option selected} other {# options selected}}"
             }
+        },
+        "NpsSlider": {
+            "input_placeholder": "Drag to define"
         }
     },
     "forms": {
@@ -37,13 +40,12 @@
             "button_next": "Next",
             "button_submit": "Submit",
             "toast_submit_success": "Form content send successfully!",
-            "toast_content_invalid": "Please fill all form fields correctly!",
-            "radio_true": "Yes",
-            "radio_false": "No"
+            "toast_content_invalid": "Please fill all form fields correctly!"
         },
         "errors": {
             "field_required": "Required field",
-            "field_require_at_least_one": "Select at least one option"
+            "field_require_at_least_one": "Select at least one option",
+            "field_require_custom": "{count, plural, other {Select at least # options}}"
         },
         "ExampleForm": {
             "steps": {
@@ -108,16 +110,42 @@
                     "title": "Planning",
                     "fields": {
                         "planning_was_planned": {
-                            "form_label": "Was your trip planned?"
+                            "form_label": "Was your trip planned?",
+                            "options": {
+                                "radio_true": "Yes",
+                                "radio_false": "No"
+                            }
                         },
                         "planning_time": {
-                            "form_label": "How far in advance was your trip planned?"
+                            "form_label": "How far in advance was your trip planned?",
+                            "options": {
+                                "0": "Less than 1 month",
+                                "1": "Between 1 and 3 months",
+                                "2": "Between 3 and 6 months",
+                                "3": "More than 6 months"
+                            }
                         },
                         "planning_information_sources": {
-                            "form_label": "What sources of information did you use for planning?"
+                            "form_label": "What sources of information did you use for planning?",
+                            "options": {
+                                "0": "Travel websites",
+                                "1": "Social networks",
+                                "2": "Recommendations from friends",
+                                "3": "Travel agencies",
+                                "4": "Printed guides",
+                                "5": "Other"
+                            }
                         },
                         "planning_organization": {
-                            "form_label": "How was your trip organized?"
+                            "form_label": "How was your trip organized?",
+                            "options": {
+                                "0": "Individual trip",
+                                "1": "Couple trip",
+                                "2": "Family trip",
+                                "3": "Group trip",
+                                "4": "With travel agency",
+                                "5": "Other"
+                            }
                         }
                     }
                 },
@@ -125,39 +153,198 @@
                     "title": "Trip",
                     "fields": {
                         "trip_has_reincidence": {
-                            "form_label": "Have you traveled here before?"
+                            "form_label": "Have you traveled here before?",
+                            "options": {
+                                "radio_true": "Yes",
+                                "radio_false": "No"
+                            }
                         },
                         "trip_reincidence": {
-                            "form_label": "How many times have you visited Ibiapaba?"
+                            "form_label": "How many times have you visited Ibiapaba?",
+                            "options": {
+                                "0": "I've visited between 2 and 5 times",
+                                "1": "I've visited between 5 and 10 times",
+                                "2": "I've visited more than 10 times",
+                                "3": "I visit once a month",
+                                "4": "I visit every weekend"
+                            }
                         },
                         "trip_know_ibiapaba_mirantes": {
-                            "form_label": "Do you know the \"Mirantes da Ibiapaba\" Route?"
+                            "form_label": "Do you know the \"Mirantes da Ibiapaba\" Route?",
+                            "options": {
+                                "radio_true": "Yes",
+                                "radio_false": "No"
+                            }
                         },
                         "trip_how_know_ibiapaba_mirantes": {
-                            "form_label": "How did you heard about the route?"
+                            "form_label": "How did you heard about the route?",
+                            "options": {
+                                "0": "Radio",
+                                "1": "TV",
+                                "2": "Magazines and newspapers",
+                                "3": "Travel agencies",
+                                "4": "Google and search engines in general",
+                                "5": "Social networks (Facebook, Instagram, others)",
+                                "6": "Experiências Ibiapaba website",
+                                "7": "Municipalities' websites",
+                                "8": "Online booking sites (OTA, such as Booking, decolar)",
+                                "9": "Specialized tourism websites",
+                                "10": "Travel blogs",
+                                "11": "Others"
+                            }
                         },
                         "trip_reasons": {
-                            "form_label": "Trip reason(s)"
+                            "form_label": "Trip reason(s)",
+                            "options": {
+                                "0": "Leisure, Outings/Rest",
+                                "1": "Business/Work",
+                                "2": "Visit to Relatives/Friends",
+                                "3": "Education, Courses, Qualification",
+                                "4": "Sports",
+                                "5": "Shopping",
+                                "6": "Medical Services",
+                                "7": "Religious",
+                                "8": "Other"
+                            }
                         },
                         "trip_stay_time": {
-                            "form_label": "Length of stay"
+                            "form_label": "Length of stay",
+                            "options": {
+                                "0": "1 day",
+                                "1": "2 to 3 days",
+                                "2": "Weekend only",
+                                "3": "4 days",
+                                "4": "5 days",
+                                "5": "1 week",
+                                "6": "15 days",
+                                "7": "More than 15 days"
+                            }
                         },
                         "trip_vehicles": {
-                            "form_label": "Vehicle(s) used"
+                            "form_label": "Vehicle(s) used",
+                            "options": {
+                                "0": "Own car",
+                                "1": "Bus",
+                                "2": "Motorcycle",
+                                "3": "Bicycle",
+                                "4": "Van",
+                                "5": "Transportation by app (Ubis, Mototáxi Tianguá, etc.)",
+                                "6": "Taxi",
+                                "7": "Motorhome/Trailer",
+                                "8": "Plane",
+                                "9": "Other"
+                            }
                         },
                         "trip_average_diary_expense": {
-                            "form_label": "How much did you spend or plan to spend on average per day?"
+                            "form_label": "How much did you spend or plan to spend on average per day?",
+                            "options": {
+                                "0": "Up to R$ 300.00",
+                                "1": "From R$ 300.00 to R$ 500.00",
+                                "2": "From R$ 500.00 to R$ 1,000.00",
+                                "3": "From R$ 1,000.00 to R$ 1,500.00",
+                                "4": "From R$ 1. 500.00 to R$ 2,000.00",
+                                "5": "From R$ 2,000.00 to R$ 3,000.00",
+                                "6": "From R$ 3,000.00 to R$ 5,000.00",
+                                "7": "Above R$ 5,000.00"
+                            }
                         },
                         "trip_hosting_types": {
-                            "form_label": "Hosting type(s)"
+                            "form_label": "Hosting type(s)",
+                            "options": {
+                                "0": "Hotel",
+                                "1": "Inn",
+                                "2": "Family/friends' house",
+                                "3": "Vacation rental",
+                                "4": "Camping",
+                                "5": "Hostel",
+                                "6": "Resort",
+                                "7": "Chalet",
+                                "8": "Motorhome/Trailer",
+                                "9": "Other"
+                            }
                         }
                     }
                 },
                 "4": {
-                    "title": "Activities"
+                    "title": "Activities",
+                    "fields": {
+                        "activities_places_visited": {
+                            "form_label": "Places visited"
+                        },
+                        "activities_events_visited": {
+                            "form_label": "Types of events visited",
+                            "options": {
+                                "0": "Museums",
+                                "1": "Religious spaces (churches, festivals)",
+                                "2": "Nature adventure activities",
+                                "3": "Theme parks"
+                            }
+                        },
+                        "activities_used_apps": {
+                            "form_label": "Apps using during the planning and trip",
+                            "options": {
+                                "0": "Maps or navigators: Waze, Google Maps, etc.",
+                                "1": "Digital tour guides",
+                                "2": "Language translators",
+                                "3": "Transport apps: Uber, 99, etc.",
+                                "4": "Social networks for sharing experiences",
+                                "5": "Accommodation booking apps: Booking, Airbnb, etc.",
+                                "6": "Restaurant and attraction review apps: TripAdvisor, Google Reviews, etc."
+                            }
+                        }
+                    }
                 },
                 "5": {
-                    "title": "Evaluation"
+                    "title": "Evaluation",
+                    "fields": {
+                        "evaluation_recommendation_rate": {
+                            "form_label": "From 1 to 10, how much would you recommend someone to visit Ibiapaba?"
+                        },
+                        "evaluation_dissatisfactions": {
+                            "form_label": "What did you like least about your visit?",
+                            "options": {
+                                "0": "Cleanliness",
+                                "1": "Street signs",
+                                "2": "Tourist signs",
+                                "3": "Conservation of streets and street furniture",
+                                "4": "Access road",
+                                "5": "Parking",
+                                "6": "Taxi",
+                                "7": "Mobility/Transport",
+                                "8": "Banks/ ATMs",
+                                "9": "Security",
+                                "10": "Lighting",
+                                "11": "Prices",
+                                "12": "Institutional website",
+                                "13": "Hospitality of residents",
+                                "14": "Hospitality of service providers and commerce",
+                                "15": "Receptive services",
+                                "16": "Accommodation",
+                                "17": "Restaurants/gastronomy",
+                                "18": "Tour guide/environmental guide",
+                                "19": "Handicrafts",
+                                "20": "Commerce in general",
+                                "21": "Cultural events",
+                                "22": "Natural attractions",
+                                "23": "Events",
+                                "24": "Leisure options",
+                                "25": " Night-time entertainment"
+                            }
+                        },
+                        "evaluation_expectation_rate": {
+                            "form_label": "What was your level of expectation before the visit? (1 to 10)"
+                        },
+                        "evaluation_satisfaction_rate": {
+                            "form_label": "How satisfied were you after your visit? (1 to 10)"
+                        },
+                        "evaluation_return_intent_rate": {
+                            "form_label": "How much do you intend to return to Ibiapaba?"
+                        },
+                        "evaluation_open_opinion": {
+                            "form_label": "Did you need a service that you couldn't find in Ibiapaba? Or do you have any recommendations for improving tourist infrastructure, equipment and services?",
+                            "input_placeholder": "We'd be very grateful to hear you :)"
+                        }
+                    }
                 }
             }
         }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1,0 +1,16 @@
+{
+    "app": {
+        "Home": {
+            "title": "Welcome to the OTIB prototype!",
+            "button_cta": "Test form"
+        }
+    },
+    "components": {
+        "ModeToggle": {
+            "toggle": "Toggle theme",
+            "light": "Light",
+            "dark": "Dark",
+            "system": "System"
+        }
+    }
+}

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -11,6 +11,155 @@
             "light": "Light",
             "dark": "Dark",
             "system": "System"
+        },
+        "LocaleSwitcher": {
+            "toggle": "Change language"
+        },
+        "FormDebugDialog": {
+            "trigger_text": "Debug form content",
+            "dialog_title": "Content sent from the form",
+            "dialog_description": "This dialog only shows in development environment"
+        },
+        "SelectWithSearch": {
+            "placeholder": {
+                "optional": "Select zero or more options",
+                "multiple": "Select at least one option",
+                "single": "Select an option"
+            },
+            "selection": {
+                "selected": "{count, plural, one {# option selected} other {# options selected}}"
+            }
+        }
+    },
+    "forms": {
+        "common": {
+            "button_back": "Back",
+            "button_next": "Next",
+            "button_submit": "Submit",
+            "toast_submit_success": "Form content send successfully!",
+            "toast_content_invalid": "Please fill all form fields correctly!",
+            "radio_true": "Yes",
+            "radio_false": "No"
+        },
+        "errors": {
+            "field_required": "Required field",
+            "field_require_at_least_one": "Select at least one option"
+        },
+        "ExampleForm": {
+            "steps": {
+                "1": {
+                    "title": "You",
+                    "fields": {
+                        "tourist_country": {
+                            "form_label": "Country"
+                        },
+                        "tourist_state": {
+                            "form_label": "State"
+                        },
+                        "tourist_city": {
+                            "form_label": "City"
+                        },
+                        "tourist_age_group": {
+                            "form_label": "Age group",
+                            "options": {
+                                "0": "Between 18 and 24 years old",
+                                "1": "Between 25 and 34 years old",
+                                "2": "Between 35 and 44 years old",
+                                "3": "Between 45 and 54 years old",
+                                "4": "Between 55 and 64 years old",
+                                "5": "65 years old or greater"
+                            }
+                        },
+                        "tourist_gender": {
+                            "form_label": "Gender",
+                            "options": {
+                                "male": "Male",
+                                "female": "Female",
+                                "non_binary": "Non binary",
+                                "other": "Other",
+                                "omit": "I prefer not to inform"
+                            }
+                        },
+                        "tourist_education": {
+                            "form_label": "Education",
+                            "options": {
+                                "0": "Incomplete elementary school",
+                                "1": "Completed elementary school",
+                                "2": "Incomplete high school",
+                                "3": "Completed high school",
+                                "4": "Incomplete higher education",
+                                "5": "Completed higher education"
+                            }
+                        },
+                        "tourist_estimated_income": {
+                            "form_label": "Estimated income",
+                            "options": {
+                                "low": "Less than R$1,000",
+                                "low_mid": "Between R$1,000 and R$3,000",
+                                "mid": "Between R$3,000 and R$5,000",
+                                "high_mid": "Between R$5,000 and R$10,000",
+                                "high": "More than R$10,000",
+                                "omit": "I prefer not to inform"
+                            }
+                        }
+                    }
+                },
+                "2": {
+                    "title": "Planning",
+                    "fields": {
+                        "planning_was_planned": {
+                            "form_label": "Was your trip planned?"
+                        },
+                        "planning_time": {
+                            "form_label": "How far in advance was your trip planned?"
+                        },
+                        "planning_information_sources": {
+                            "form_label": "What sources of information did you use for planning?"
+                        },
+                        "planning_organization": {
+                            "form_label": "How was your trip organized?"
+                        }
+                    }
+                },
+                "3": {
+                    "title": "Trip",
+                    "fields": {
+                        "trip_has_reincidence": {
+                            "form_label": "Have you traveled here before?"
+                        },
+                        "trip_reincidence": {
+                            "form_label": "How many times have you visited Ibiapaba?"
+                        },
+                        "trip_know_ibiapaba_mirantes": {
+                            "form_label": "Do you know the \"Mirantes da Ibiapaba\" Route?"
+                        },
+                        "trip_how_know_ibiapaba_mirantes": {
+                            "form_label": "How did you heard about the route?"
+                        },
+                        "trip_reasons": {
+                            "form_label": "Trip reason(s)"
+                        },
+                        "trip_stay_time": {
+                            "form_label": "Length of stay"
+                        },
+                        "trip_vehicles": {
+                            "form_label": "Vehicle(s) used"
+                        },
+                        "trip_average_diary_expense": {
+                            "form_label": "How much did you spend or plan to spend on average per day?"
+                        },
+                        "trip_hosting_types": {
+                            "form_label": "Hosting type(s)"
+                        }
+                    }
+                },
+                "4": {
+                    "title": "Activities"
+                },
+                "5": {
+                    "title": "Evaluation"
+                }
+            }
         }
     }
 }

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -18,17 +18,20 @@
         "FormDebugDialog": {
             "trigger_text": "Depurar contenido del formulario",
             "dialog_title": "Contenido enviado desde el formulario",
-            "dialog_description": "Este diálogo solo se muestra en entorno de desarrollo"
+            "dialog_description": "Este diálogo solo aparece en el entorno de desarrollo"
         },
         "SelectWithSearch": {
             "placeholder": {
-                "optional": "Seleccione cero o más opciones",
-                "multiple": "Seleccione al menos una opción",
-                "single": "Seleccione una opción"
+                "optional": "Selecciona una o más opciones",
+                "multiple": "Selecciona al menos una opción",
+                "single": "Selecciona una opción"
             },
             "selection": {
                 "selected": "{count, plural, one {# opción seleccionada} other {# opciones seleccionadas}}"
             }
+        },
+        "NpsSlider": {
+            "input_placeholder": "Arrastra para definir"
         }
     },
     "forms": {
@@ -37,13 +40,12 @@
             "button_next": "Siguiente",
             "button_submit": "Enviar",
             "toast_submit_success": "¡Contenido del formulario enviado con éxito!",
-            "toast_content_invalid": "¡Por favor, complete todos los campos del formulario correctamente!",
-            "radio_true": "Sí",
-            "radio_false": "No"
+            "toast_content_invalid": "¡Por favor, rellena correctamente todos los campos del formulario!"
         },
         "errors": {
             "field_required": "Campo obligatorio",
-            "field_require_at_least_one": "Seleccione al menos una opción"
+            "field_require_at_least_one": "Selecciona al menos una opción",
+            "field_require_custom": "{count, plural, other {Selecciona al menos # opciones}}"
         },
         "ExampleForm": {
             "steps": {
@@ -92,7 +94,7 @@
                             }
                         },
                         "tourist_estimated_income": {
-                            "form_label": "Ingreso estimado",
+                            "form_label": "Renta estimada",
                             "options": {
                                 "low": "Menos de R$1.000",
                                 "low_mid": "Entre R$1.000 y R$3.000",
@@ -108,16 +110,42 @@
                     "title": "Planificación",
                     "fields": {
                         "planning_was_planned": {
-                            "form_label": "¿Fue planificado su viaje?"
+                            "form_label": "¿Tu viaje fue planificado?",
+                            "options": {
+                                "radio_true": "Sí",
+                                "radio_false": "No"
+                            }
                         },
                         "planning_time": {
-                            "form_label": "¿Con cuánta anticipación planificó su viaje?"
+                            "form_label": "¿Con cuánta anticipación fue planificado tu viaje?",
+                            "options": {
+                                "0": "Menos de 1 mes",
+                                "1": "Entre 1 y 3 meses",
+                                "2": "Entre 3 y 6 meses",
+                                "3": "Más de 6 meses"
+                            }
                         },
                         "planning_information_sources": {
-                            "form_label": "¿Qué fuentes de información utilizó para planificar?"
+                            "form_label": "¿Qué fuentes de información usaste para planificar?",
+                            "options": {
+                                "0": "Sitios web de viajes",
+                                "1": "Redes sociales",
+                                "2": "Recomendaciones de amigos",
+                                "3": "Agencias de viajes",
+                                "4": "Guías impresas",
+                                "5": "Otro"
+                            }
                         },
                         "planning_organization": {
-                            "form_label": "¿Cómo fue organizado su viaje?"
+                            "form_label": "¿Cómo fue organizado tu viaje?",
+                            "options": {
+                                "0": "Viaje individual",
+                                "1": "Viaje en pareja",
+                                "2": "Viaje familiar",
+                                "3": "Viaje en grupo",
+                                "4": "Con agencia de viajes",
+                                "5": "Otro"
+                            }
                         }
                     }
                 },
@@ -125,39 +153,198 @@
                     "title": "Viaje",
                     "fields": {
                         "trip_has_reincidence": {
-                            "form_label": "¿Ha viajado aquí antes?"
+                            "form_label": "¿Has viajado aquí antes?",
+                            "options": {
+                                "radio_true": "Sí",
+                                "radio_false": "No"
+                            }
                         },
                         "trip_reincidence": {
-                            "form_label": "¿Cuántas veces ha visitado Ibiapaba?"
+                            "form_label": "¿Cuántas veces has visitado Ibiapaba?",
+                            "options": {
+                                "0": "He visitado entre 2 y 5 veces",
+                                "1": "He visitado entre 5 y 10 veces",
+                                "2": "He visitado más de 10 veces",
+                                "3": "Visito una vez al mes",
+                                "4": "Visito todos los fines de semana"
+                            }
                         },
                         "trip_know_ibiapaba_mirantes": {
-                            "form_label": "¿Conoce la Ruta \"Mirantes da Ibiapaba\"?"
+                            "form_label": "¿Conoces la Ruta \"Mirantes da Ibiapaba\"?",
+                            "options": {
+                                "radio_true": "Sí",
+                                "radio_false": "No"
+                            }
                         },
                         "trip_how_know_ibiapaba_mirantes": {
-                            "form_label": "¿Cómo se enteró de la ruta?"
+                            "form_label": "¿Cómo supiste de la ruta?",
+                            "options": {
+                                "0": "Radio",
+                                "1": "TV",
+                                "2": "Revistas y periódicos",
+                                "3": "Agencias de viajes",
+                                "4": "Google y otros buscadores",
+                                "5": "Redes sociales (Facebook, Instagram, etc.)",
+                                "6": "Sitio web de Experiências Ibiapaba",
+                                "7": "Sitios web de los municipios",
+                                "8": "Sitios de reserva en línea (Booking, Decolar)",
+                                "9": "Sitios especializados en turismo",
+                                "10": "Blogs de viajes",
+                                "11": "Otros"
+                            }
                         },
                         "trip_reasons": {
-                            "form_label": "Motivo(s) del viaje"
+                            "form_label": "Motivo(s) del viaje",
+                            "options": {
+                                "0": "Ocio, Paseos/Descanso",
+                                "1": "Negocios/Trabajo",
+                                "2": "Visita a Familiares/Amigos",
+                                "3": "Educación, Cursos, Capacitación",
+                                "4": "Deportes",
+                                "5": "Compras",
+                                "6": "Servicios médicos",
+                                "7": "Religioso",
+                                "8": "Otro"
+                            }
                         },
                         "trip_stay_time": {
-                            "form_label": "Duración de la estadía"
+                            "form_label": "Duración de la estadía",
+                            "options": {
+                                "0": "1 día",
+                                "1": "2 a 3 días",
+                                "2": "Solo fin de semana",
+                                "3": "4 días",
+                                "4": "5 días",
+                                "5": "1 semana",
+                                "6": "15 días",
+                                "7": "Más de 15 días"
+                            }
                         },
                         "trip_vehicles": {
-                            "form_label": "Vehículo(s) utilizado(s)"
+                            "form_label": "Vehículo(s) utilizado(s)",
+                            "options": {
+                                "0": "Auto propio",
+                                "1": "Autobús",
+                                "2": "Motocicleta",
+                                "3": "Bicicleta",
+                                "4": "Furgoneta",
+                                "5": "Transporte por app (Ubis, Mototaxi Tianguá, etc.)",
+                                "6": "Taxi",
+                                "7": "Casa rodante/Remolque",
+                                "8": "Avión",
+                                "9": "Otro"
+                            }
                         },
                         "trip_average_diary_expense": {
-                            "form_label": "¿Cuánto gastó o planea gastar en promedio por día?"
+                            "form_label": "¿Cuánto gastaste o planeaste gastar en promedio por día?",
+                            "options": {
+                                "0": "Hasta R$300,00",
+                                "1": "De R$300,00 a R$500,00",
+                                "2": "De R$500,00 a R$1.000,00",
+                                "3": "De R$1.000,00 a R$1.500,00",
+                                "4": "De R$1.500,00 a R$2.000,00",
+                                "5": "De R$2.000,00 a R$3.000,00",
+                                "6": "De R$3.000,00 a R$5.000,00",
+                                "7": "Más de R$5.000,00"
+                            }
                         },
                         "trip_hosting_types": {
-                            "form_label": "Tipo(s) de hospedaje"
+                            "form_label": "Tipo(s) de alojamiento",
+                            "options": {
+                                "0": "Hotel",
+                                "1": "Posada",
+                                "2": "Casa de familiares/amigos",
+                                "3": "Alquiler vacacional",
+                                "4": "Camping",
+                                "5": "Hostal",
+                                "6": "Resort",
+                                "7": "Chalet",
+                                "8": "Casa rodante/Remolque",
+                                "9": "Otro"
+                            }
                         }
                     }
                 },
                 "4": {
-                    "title": "Actividades"
+                    "title": "Actividades",
+                    "fields": {
+                        "activities_places_visited": {
+                            "form_label": "Lugares visitados"
+                        },
+                        "activities_events_visited": {
+                            "form_label": "Tipos de eventos visitados",
+                            "options": {
+                                "0": "Museos",
+                                "1": "Espacios religiosos (iglesias, festivales)",
+                                "2": "Actividades de aventura en la naturaleza",
+                                "3": "Parques temáticos"
+                            }
+                        },
+                        "activities_used_apps": {
+                            "form_label": "Apps utilizadas durante la planificación y el viaje",
+                            "options": {
+                                "0": "Mapas o navegadores: Waze, Google Maps, etc.",
+                                "1": "Guías turísticas digitales",
+                                "2": "Traductores de idiomas",
+                                "3": "Apps de transporte: Uber, 99, etc.",
+                                "4": "Redes sociales para compartir experiencias",
+                                "5": "Apps de reserva de alojamiento: Booking, Airbnb, etc.",
+                                "6": "Apps de reseñas de restaurantes y atracciones: TripAdvisor, Google Reviews, etc."
+                            }
+                        }
+                    }
                 },
                 "5": {
-                    "title": "Evaluación"
+                    "title": "Evaluación",
+                    "fields": {
+                        "evaluation_recommendation_rate": {
+                            "form_label": "Del 1 al 10, ¿cuánto recomendarías visitar Ibiapaba?"
+                        },
+                        "evaluation_dissatisfactions": {
+                            "form_label": "¿Qué fue lo que menos te gustó de tu visita?",
+                            "options": {
+                                "0": "Limpieza",
+                                "1": "Señalización de calles",
+                                "2": "Señalización turística",
+                                "3": "Conservación de calles y mobiliario urbano",
+                                "4": "Vía de acceso",
+                                "5": "Estacionamiento",
+                                "6": "Taxi",
+                                "7": "Movilidad/Transporte",
+                                "8": "Bancos/ Cajeros automáticos",
+                                "9": "Seguridad",
+                                "10": "Iluminación",
+                                "11": "Precios",
+                                "12": "Sitio web institucional",
+                                "13": "Hospitalidad de los residentes",
+                                "14": "Hospitalidad de prestadores de servicios y comercios",
+                                "15": "Servicios receptivos",
+                                "16": "Alojamiento",
+                                "17": "Restaurantes/gastronomía",
+                                "18": "Guía turístico/ambiental",
+                                "19": "Artesanía",
+                                "20": "Comercio en general",
+                                "21": "Eventos culturales",
+                                "22": "Atracciones naturales",
+                                "23": "Eventos",
+                                "24": "Opciones de ocio",
+                                "25": "Entretenimiento nocturno"
+                            }
+                        },
+                        "evaluation_expectation_rate": {
+                            "form_label": "¿Cuál era tu nivel de expectativa antes de la visita? (1 a 10)"
+                        },
+                        "evaluation_satisfaction_rate": {
+                            "form_label": "¿Qué tan satisfecho estuviste después de tu visita? (1 a 10)"
+                        },
+                        "evaluation_return_intent_rate": {
+                            "form_label": "¿Qué tanto deseas volver a Ibiapaba?"
+                        },
+                        "evaluation_open_opinion": {
+                            "form_label": "¿Necesitaste algún servicio que no encontraste en Ibiapaba? ¿Tienes alguna recomendación para mejorar la infraestructura, equipos y servicios turísticos?",
+                            "input_placeholder": "¡Nos encantaría conocer tu opinión! :)"
+                        }
+                    }
                 }
             }
         }

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -1,8 +1,8 @@
 {
     "app": {
         "Home": {
-            "title": "¡Bienvenido al prototipo OTIB!",
-            "button_cta": "Formulario de prueba"
+            "title": "¡Bienvenido al prototipo de OTIB!",
+            "button_cta": "Probar formulario"
         }
     },
     "components": {
@@ -11,6 +11,155 @@
             "light": "Claro",
             "dark": "Oscuro",
             "system": "Sistema"
+        },
+        "LocaleSwitcher": {
+            "toggle": "Cambiar idioma"
+        },
+        "FormDebugDialog": {
+            "trigger_text": "Depurar contenido del formulario",
+            "dialog_title": "Contenido enviado desde el formulario",
+            "dialog_description": "Este diálogo solo se muestra en entorno de desarrollo"
+        },
+        "SelectWithSearch": {
+            "placeholder": {
+                "optional": "Seleccione cero o más opciones",
+                "multiple": "Seleccione al menos una opción",
+                "single": "Seleccione una opción"
+            },
+            "selection": {
+                "selected": "{count, plural, one {# opción seleccionada} other {# opciones seleccionadas}}"
+            }
+        }
+    },
+    "forms": {
+        "common": {
+            "button_back": "Atrás",
+            "button_next": "Siguiente",
+            "button_submit": "Enviar",
+            "toast_submit_success": "¡Contenido del formulario enviado con éxito!",
+            "toast_content_invalid": "¡Por favor, complete todos los campos del formulario correctamente!",
+            "radio_true": "Sí",
+            "radio_false": "No"
+        },
+        "errors": {
+            "field_required": "Campo obligatorio",
+            "field_require_at_least_one": "Seleccione al menos una opción"
+        },
+        "ExampleForm": {
+            "steps": {
+                "1": {
+                    "title": "Tú",
+                    "fields": {
+                        "tourist_country": {
+                            "form_label": "País"
+                        },
+                        "tourist_state": {
+                            "form_label": "Estado"
+                        },
+                        "tourist_city": {
+                            "form_label": "Ciudad"
+                        },
+                        "tourist_age_group": {
+                            "form_label": "Grupo de edad",
+                            "options": {
+                                "0": "Entre 18 y 24 años",
+                                "1": "Entre 25 y 34 años",
+                                "2": "Entre 35 y 44 años",
+                                "3": "Entre 45 y 54 años",
+                                "4": "Entre 55 y 64 años",
+                                "5": "65 años o más"
+                            }
+                        },
+                        "tourist_gender": {
+                            "form_label": "Género",
+                            "options": {
+                                "male": "Masculino",
+                                "female": "Femenino",
+                                "non_binary": "No binario",
+                                "other": "Otro",
+                                "omit": "Prefiero no informar"
+                            }
+                        },
+                        "tourist_education": {
+                            "form_label": "Educación",
+                            "options": {
+                                "0": "Primaria incompleta",
+                                "1": "Primaria completa",
+                                "2": "Secundaria incompleta",
+                                "3": "Secundaria completa",
+                                "4": "Educación superior incompleta",
+                                "5": "Educación superior completa"
+                            }
+                        },
+                        "tourist_estimated_income": {
+                            "form_label": "Ingreso estimado",
+                            "options": {
+                                "low": "Menos de R$1.000",
+                                "low_mid": "Entre R$1.000 y R$3.000",
+                                "mid": "Entre R$3.000 y R$5.000",
+                                "high_mid": "Entre R$5.000 y R$10.000",
+                                "high": "Más de R$10.000",
+                                "omit": "Prefiero no informar"
+                            }
+                        }
+                    }
+                },
+                "2": {
+                    "title": "Planificación",
+                    "fields": {
+                        "planning_was_planned": {
+                            "form_label": "¿Fue planificado su viaje?"
+                        },
+                        "planning_time": {
+                            "form_label": "¿Con cuánta anticipación planificó su viaje?"
+                        },
+                        "planning_information_sources": {
+                            "form_label": "¿Qué fuentes de información utilizó para planificar?"
+                        },
+                        "planning_organization": {
+                            "form_label": "¿Cómo fue organizado su viaje?"
+                        }
+                    }
+                },
+                "3": {
+                    "title": "Viaje",
+                    "fields": {
+                        "trip_has_reincidence": {
+                            "form_label": "¿Ha viajado aquí antes?"
+                        },
+                        "trip_reincidence": {
+                            "form_label": "¿Cuántas veces ha visitado Ibiapaba?"
+                        },
+                        "trip_know_ibiapaba_mirantes": {
+                            "form_label": "¿Conoce la Ruta \"Mirantes da Ibiapaba\"?"
+                        },
+                        "trip_how_know_ibiapaba_mirantes": {
+                            "form_label": "¿Cómo se enteró de la ruta?"
+                        },
+                        "trip_reasons": {
+                            "form_label": "Motivo(s) del viaje"
+                        },
+                        "trip_stay_time": {
+                            "form_label": "Duración de la estadía"
+                        },
+                        "trip_vehicles": {
+                            "form_label": "Vehículo(s) utilizado(s)"
+                        },
+                        "trip_average_diary_expense": {
+                            "form_label": "¿Cuánto gastó o planea gastar en promedio por día?"
+                        },
+                        "trip_hosting_types": {
+                            "form_label": "Tipo(s) de hospedaje"
+                        }
+                    }
+                },
+                "4": {
+                    "title": "Actividades"
+                },
+                "5": {
+                    "title": "Evaluación"
+                }
+            }
         }
     }
 }

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -1,0 +1,16 @@
+{
+    "app": {
+        "Home": {
+            "title": "¡Bienvenido al prototipo OTIB!",
+            "button_cta": "Formulario de prueba"
+        }
+    },
+    "components": {
+        "ModeToggle": {
+            "toggle": "Cambiar tema",
+            "light": "Claro",
+            "dark": "Oscuro",
+            "system": "Sistema"
+        }
+    }
+}

--- a/public/locales/pt-BR.json
+++ b/public/locales/pt-BR.json
@@ -1,16 +1,165 @@
 {
     "app": {
         "Home": {
-            "title": "Bem vindo ao protótipo do OTIB!",
-            "button_cta": "Formulário de teste"
+            "title": "Bem-vindo ao protótipo do OTIB!",
+            "button_cta": "Testar formulário"
         }
     },
     "components": {
         "ModeToggle": {
-            "toggle": "Trocar tema",
+            "toggle": "Alternar tema",
             "light": "Claro",
             "dark": "Escuro",
             "system": "Sistema"
+        },
+        "LocaleSwitcher": {
+            "toggle": "Alterar idioma"
+        },
+        "FormDebugDialog": {
+            "trigger_text": "Depurar conteúdo do formulário",
+            "dialog_title": "Conteúdo enviado pelo formulário",
+            "dialog_description": "Este diálogo aparece apenas no ambiente de desenvolvimento"
+        },
+        "SelectWithSearch": {
+            "placeholder": {
+                "optional": "Selecione zero ou mais opções",
+                "multiple": "Selecione pelo menos uma opção",
+                "single": "Selecione uma opção"
+            },
+            "selection": {
+                "selected": "{count, plural, one {# opção selecionada} other {# opções selecionadas}}"
+            }
+        }
+    },
+    "forms": {
+        "common": {
+            "button_back": "Voltar",
+            "button_next": "Avançar",
+            "button_submit": "Enviar",
+            "toast_submit_success": "Conteúdo do formulário enviado com sucesso!",
+            "toast_content_invalid": "Por favor, preencha todos os campos corretamente!",
+            "radio_true": "Sim",
+            "radio_false": "Não"
+        },
+        "errors": {
+            "field_required": "Campo obrigatório",
+            "field_require_at_least_one": "Selecione pelo menos uma opção"
+        },
+        "ExampleForm": {
+            "steps": {
+                "1": {
+                    "title": "Você",
+                    "fields": {
+                        "tourist_country": {
+                            "form_label": "País"
+                        },
+                        "tourist_state": {
+                            "form_label": "Estado"
+                        },
+                        "tourist_city": {
+                            "form_label": "Cidade"
+                        },
+                        "tourist_age_group": {
+                            "form_label": "Faixa etária",
+                            "options": {
+                                "0": "Entre 18 e 24 anos",
+                                "1": "Entre 25 e 34 anos",
+                                "2": "Entre 35 e 44 anos",
+                                "3": "Entre 45 e 54 anos",
+                                "4": "Entre 55 e 64 anos",
+                                "5": "65 anos ou mais"
+                            }
+                        },
+                        "tourist_gender": {
+                            "form_label": "Gênero",
+                            "options": {
+                                "male": "Masculino",
+                                "female": "Feminino",
+                                "non_binary": "Não binário",
+                                "other": "Outro",
+                                "omit": "Prefiro não informar"
+                            }
+                        },
+                        "tourist_education": {
+                            "form_label": "Escolaridade",
+                            "options": {
+                                "0": "Ensino fundamental incompleto",
+                                "1": "Ensino fundamental completo",
+                                "2": "Ensino médio incompleto",
+                                "3": "Ensino médio completo",
+                                "4": "Ensino superior incompleto",
+                                "5": "Ensino superior completo"
+                            }
+                        },
+                        "tourist_estimated_income": {
+                            "form_label": "Renda estimada",
+                            "options": {
+                                "low": "Menos de R$1.000",
+                                "low_mid": "Entre R$1.000 e R$3.000",
+                                "mid": "Entre R$3.000 e R$5.000",
+                                "high_mid": "Entre R$5.000 e R$10.000",
+                                "high": "Mais de R$10.000",
+                                "omit": "Prefiro não informar"
+                            }
+                        }
+                    }
+                },
+                "2": {
+                    "title": "Planejamento",
+                    "fields": {
+                        "planning_was_planned": {
+                            "form_label": "Sua viagem foi planejada?"
+                        },
+                        "planning_time": {
+                            "form_label": "Com que antecedência a viagem foi planejada?"
+                        },
+                        "planning_information_sources": {
+                            "form_label": "Quais fontes de informação você utilizou para planejar?"
+                        },
+                        "planning_organization": {
+                            "form_label": "Como a sua viagem foi organizada?"
+                        }
+                    }
+                },
+                "3": {
+                    "title": "Viagem",
+                    "fields": {
+                        "trip_has_reincidence": {
+                            "form_label": "Você já viajou para cá antes?"
+                        },
+                        "trip_reincidence": {
+                            "form_label": "Quantas vezes você visitou a Ibiapaba?"
+                        },
+                        "trip_know_ibiapaba_mirantes": {
+                            "form_label": "Você conhece a Rota \"Mirantes da Ibiapaba\"?"
+                        },
+                        "trip_how_know_ibiapaba_mirantes": {
+                            "form_label": "Como você ficou sabendo da rota?"
+                        },
+                        "trip_reasons": {
+                            "form_label": "Motivo(s) da viagem"
+                        },
+                        "trip_stay_time": {
+                            "form_label": "Tempo de permanência"
+                        },
+                        "trip_vehicles": {
+                            "form_label": "Veículo(s) utilizado(s)"
+                        },
+                        "trip_average_diary_expense": {
+                            "form_label": "Quanto você gastou ou planeja gastar, em média, por dia?"
+                        },
+                        "trip_hosting_types": {
+                            "form_label": "Tipo(s) de hospedagem"
+                        }
+                    }
+                },
+                "4": {
+                    "title": "Atividades"
+                },
+                "5": {
+                    "title": "Avaliação"
+                }
+            }
         }
     }
 }

--- a/public/locales/pt-BR.json
+++ b/public/locales/pt-BR.json
@@ -13,12 +13,12 @@
             "system": "Sistema"
         },
         "LocaleSwitcher": {
-            "toggle": "Alterar idioma"
+            "toggle": "Mudar idioma"
         },
         "FormDebugDialog": {
             "trigger_text": "Depurar conteúdo do formulário",
             "dialog_title": "Conteúdo enviado pelo formulário",
-            "dialog_description": "Este diálogo aparece apenas no ambiente de desenvolvimento"
+            "dialog_description": "Este diálogo aparece apenas em ambiente de desenvolvimento"
         },
         "SelectWithSearch": {
             "placeholder": {
@@ -29,21 +29,23 @@
             "selection": {
                 "selected": "{count, plural, one {# opção selecionada} other {# opções selecionadas}}"
             }
+        },
+        "NpsSlider": {
+            "input_placeholder": "Arraste para definir"
         }
     },
     "forms": {
         "common": {
             "button_back": "Voltar",
-            "button_next": "Avançar",
+            "button_next": "Próximo",
             "button_submit": "Enviar",
             "toast_submit_success": "Conteúdo do formulário enviado com sucesso!",
-            "toast_content_invalid": "Por favor, preencha todos os campos corretamente!",
-            "radio_true": "Sim",
-            "radio_false": "Não"
+            "toast_content_invalid": "Por favor, preencha todos os campos do formulário corretamente!"
         },
         "errors": {
             "field_required": "Campo obrigatório",
-            "field_require_at_least_one": "Selecione pelo menos uma opção"
+            "field_require_at_least_one": "Selecione pelo menos uma opção",
+            "field_require_custom": "{count, plural, other {Selecione pelo menos # opções}}"
         },
         "ExampleForm": {
             "steps": {
@@ -108,16 +110,42 @@
                     "title": "Planejamento",
                     "fields": {
                         "planning_was_planned": {
-                            "form_label": "Sua viagem foi planejada?"
+                            "form_label": "Sua viagem foi planejada?",
+                            "options": {
+                                "radio_true": "Sim",
+                                "radio_false": "Não"
+                            }
                         },
                         "planning_time": {
-                            "form_label": "Com que antecedência a viagem foi planejada?"
+                            "form_label": "Com que antecedência sua viagem foi planejada?",
+                            "options": {
+                                "0": "Menos de 1 mês",
+                                "1": "Entre 1 e 3 meses",
+                                "2": "Entre 3 e 6 meses",
+                                "3": "Mais de 6 meses"
+                            }
                         },
                         "planning_information_sources": {
-                            "form_label": "Quais fontes de informação você utilizou para planejar?"
+                            "form_label": "Quais fontes de informação você utilizou para o planejamento?",
+                            "options": {
+                                "0": "Sites de viagem",
+                                "1": "Redes sociais",
+                                "2": "Recomendações de amigos",
+                                "3": "Agências de viagem",
+                                "4": "Guias impressos",
+                                "5": "Outro"
+                            }
                         },
                         "planning_organization": {
-                            "form_label": "Como a sua viagem foi organizada?"
+                            "form_label": "Como sua viagem foi organizada?",
+                            "options": {
+                                "0": "Viagem individual",
+                                "1": "Viagem em casal",
+                                "2": "Viagem em família",
+                                "3": "Viagem em grupo",
+                                "4": "Com agência de viagem",
+                                "5": "Outro"
+                            }
                         }
                     }
                 },
@@ -125,39 +153,198 @@
                     "title": "Viagem",
                     "fields": {
                         "trip_has_reincidence": {
-                            "form_label": "Você já viajou para cá antes?"
+                            "form_label": "Você já viajou para cá antes?",
+                            "options": {
+                                "radio_true": "Sim",
+                                "radio_false": "Não"
+                            }
                         },
                         "trip_reincidence": {
-                            "form_label": "Quantas vezes você visitou a Ibiapaba?"
+                            "form_label": "Quantas vezes você visitou a Ibiapaba?",
+                            "options": {
+                                "0": "Visitei entre 2 e 5 vezes",
+                                "1": "Visitei entre 5 e 10 vezes",
+                                "2": "Visitei mais de 10 vezes",
+                                "3": "Visito uma vez por mês",
+                                "4": "Visito todo fim de semana"
+                            }
                         },
                         "trip_know_ibiapaba_mirantes": {
-                            "form_label": "Você conhece a Rota \"Mirantes da Ibiapaba\"?"
+                            "form_label": "Você conhece a Rota \"Mirantes da Ibiapaba\"?",
+                            "options": {
+                                "radio_true": "Sim",
+                                "radio_false": "Não"
+                            }
                         },
                         "trip_how_know_ibiapaba_mirantes": {
-                            "form_label": "Como você ficou sabendo da rota?"
+                            "form_label": "Como você soube da rota?",
+                            "options": {
+                                "0": "Rádio",
+                                "1": "TV",
+                                "2": "Revistas e jornais",
+                                "3": "Agências de viagem",
+                                "4": "Google e outros buscadores",
+                                "5": "Redes sociais (Facebook, Instagram, etc.)",
+                                "6": "Site Experiências Ibiapaba",
+                                "7": "Sites das prefeituras",
+                                "8": "Sites de reservas online (OTA, como Booking, Decolar)",
+                                "9": "Sites especializados em turismo",
+                                "10": "Blogs de viagem",
+                                "11": "Outros"
+                            }
                         },
                         "trip_reasons": {
-                            "form_label": "Motivo(s) da viagem"
+                            "form_label": "Motivo(s) da viagem",
+                            "options": {
+                                "0": "Lazer, Passeios/Descanso",
+                                "1": "Negócios/Trabalho",
+                                "2": "Visita a Parentes/Amigos",
+                                "3": "Educação, Cursos, Qualificação",
+                                "4": "Esportes",
+                                "5": "Compras",
+                                "6": "Serviços Médicos",
+                                "7": "Religioso",
+                                "8": "Outro"
+                            }
                         },
                         "trip_stay_time": {
-                            "form_label": "Tempo de permanência"
+                            "form_label": "Duração da estadia",
+                            "options": {
+                                "0": "1 dia",
+                                "1": "2 a 3 dias",
+                                "2": "Apenas fim de semana",
+                                "3": "4 dias",
+                                "4": "5 dias",
+                                "5": "1 semana",
+                                "6": "15 dias",
+                                "7": "Mais de 15 dias"
+                            }
                         },
                         "trip_vehicles": {
-                            "form_label": "Veículo(s) utilizado(s)"
+                            "form_label": "Meio(s) de transporte utilizado(s)",
+                            "options": {
+                                "0": "Carro próprio",
+                                "1": "Ônibus",
+                                "2": "Motocicleta",
+                                "3": "Bicicleta",
+                                "4": "Van",
+                                "5": "Transporte por aplicativo (Uber, Mototáxi Tianguá, etc.)",
+                                "6": "Táxi",
+                                "7": "Motorhome/Trailer",
+                                "8": "Avião",
+                                "9": "Outro"
+                            }
                         },
                         "trip_average_diary_expense": {
-                            "form_label": "Quanto você gastou ou planeja gastar, em média, por dia?"
+                            "form_label": "Quanto você gastou ou planeja gastar em média por dia?",
+                            "options": {
+                                "0": "Até R$ 300,00",
+                                "1": "De R$ 300,00 a R$ 500,00",
+                                "2": "De R$ 500,00 a R$ 1.000,00",
+                                "3": "De R$ 1.000,00 a R$ 1.500,00",
+                                "4": "De R$ 1.500,00 a R$ 2.000,00",
+                                "5": "De R$ 2.000,00 a R$ 3.000,00",
+                                "6": "De R$ 3.000,00 a R$ 5.000,00",
+                                "7": "Acima de R$ 5.000,00"
+                            }
                         },
                         "trip_hosting_types": {
-                            "form_label": "Tipo(s) de hospedagem"
+                            "form_label": "Tipo(s) de hospedagem",
+                            "options": {
+                                "0": "Hotel",
+                                "1": "Pousada",
+                                "2": "Casa de familiares/amigos",
+                                "3": "Aluguel de temporada",
+                                "4": "Camping",
+                                "5": "Hostel",
+                                "6": "Resort",
+                                "7": "Chalé",
+                                "8": "Motorhome/Trailer",
+                                "9": "Outro"
+                            }
                         }
                     }
                 },
                 "4": {
-                    "title": "Atividades"
+                    "title": "Atividades",
+                    "fields": {
+                        "activities_places_visited": {
+                            "form_label": "Locais visitados"
+                        },
+                        "activities_events_visited": {
+                            "form_label": "Tipos de eventos visitados",
+                            "options": {
+                                "0": "Museus",
+                                "1": "Espaços religiosos (igrejas, festas)",
+                                "2": "Atividades de aventura na natureza",
+                                "3": "Parques temáticos"
+                            }
+                        },
+                        "activities_used_apps": {
+                            "form_label": "Aplicativos utilizados no planejamento e durante a viagem",
+                            "options": {
+                                "0": "Mapas ou navegadores: Waze, Google Maps, etc.",
+                                "1": "Guias turísticos digitais",
+                                "2": "Tradutores de idioma",
+                                "3": "Apps de transporte: Uber, 99, etc.",
+                                "4": "Redes sociais para compartilhar experiências",
+                                "5": "Apps de reserva de hospedagem: Booking, Airbnb, etc.",
+                                "6": "Apps de avaliação de restaurantes e atrações: TripAdvisor, Google Reviews, etc."
+                            }
+                        }
+                    }
                 },
                 "5": {
-                    "title": "Avaliação"
+                    "title": "Avaliação",
+                    "fields": {
+                        "evaluation_recommendation_rate": {
+                            "form_label": "De 1 a 10, quanto você recomendaria uma visita à Ibiapaba?"
+                        },
+                        "evaluation_dissatisfactions": {
+                            "form_label": "Do que você menos gostou na sua visita?",
+                            "options": {
+                                "0": "Limpeza",
+                                "1": "Sinalização das ruas",
+                                "2": "Sinalização turística",
+                                "3": "Conservação de ruas e mobiliário urbano",
+                                "4": "Via de acesso",
+                                "5": "Estacionamento",
+                                "6": "Táxi",
+                                "7": "Mobilidade/Transporte",
+                                "8": "Bancos/ Caixas eletrônicos",
+                                "9": "Segurança",
+                                "10": "Iluminação",
+                                "11": "Preços",
+                                "12": "Site institucional",
+                                "13": "Hospitalidade dos moradores",
+                                "14": "Hospitalidade dos prestadores de serviço e comércio",
+                                "15": "Serviços receptivos",
+                                "16": "Hospedagem",
+                                "17": "Restaurantes/gastronomia",
+                                "18": "Guia turístico/ambiental",
+                                "19": "Artesanato",
+                                "20": "Comércio em geral",
+                                "21": "Eventos culturais",
+                                "22": "Atrativos naturais",
+                                "23": "Eventos",
+                                "24": "Opções de lazer",
+                                "25": "Entretenimento noturno"
+                            }
+                        },
+                        "evaluation_expectation_rate": {
+                            "form_label": "Qual era seu nível de expectativa antes da visita? (1 a 10)"
+                        },
+                        "evaluation_satisfaction_rate": {
+                            "form_label": "Quão satisfeito(a) você ficou após a visita? (1 a 10)"
+                        },
+                        "evaluation_return_intent_rate": {
+                            "form_label": "Quanto você pretende voltar à Ibiapaba?"
+                        },
+                        "evaluation_open_opinion": {
+                            "form_label": "Você precisou de algum serviço que não encontrou na Ibiapaba? Ou tem alguma sugestão para melhorar a infraestrutura turística, os equipamentos e serviços?",
+                            "input_placeholder": "Agradeceríamos muito por sua opinião :)"
+                        }
+                    }
                 }
             }
         }

--- a/public/locales/pt-BR.json
+++ b/public/locales/pt-BR.json
@@ -1,0 +1,16 @@
+{
+    "app": {
+        "Home": {
+            "title": "Bem vindo ao protótipo do OTIB!",
+            "button_cta": "Formulário de teste"
+        }
+    },
+    "components": {
+        "ModeToggle": {
+            "toggle": "Trocar tema",
+            "light": "Claro",
+            "dark": "Escuro",
+            "system": "Sistema"
+        }
+    }
+}

--- a/src/@types/form-step.d.ts
+++ b/src/@types/form-step.d.ts
@@ -1,9 +1,10 @@
 import { LucideIcon } from 'lucide-react';
 import { AnyZodObject } from 'zod';
+import { TFunction } from './next-intl';
 
 export type FormStep = {
 	step: React.ComponentType;
-	schema?: AnyZodObject;
+	schema?: AnyZodObject | TFunction;
 	number: number;
 	title?: string;
 	description?: string;

--- a/src/@types/next-intl.d.ts
+++ b/src/@types/next-intl.d.ts
@@ -1,0 +1,11 @@
+import { routing } from '@/i18n/routing';
+import { formats } from '@/i18n/request';
+import messages from '../../public/locales/en.json';
+
+declare module 'next-intl' {
+	interface AppConfig {
+		Locale: (typeof routing.locales)[number];
+		Messages: typeof messages;
+		Formats: typeof formats;
+	}
+}

--- a/src/@types/next-intl.d.ts
+++ b/src/@types/next-intl.d.ts
@@ -9,3 +9,5 @@ declare module 'next-intl' {
 		Formats: typeof formats;
 	}
 }
+
+export type TFunction<T = string> = typeof ReturnType<typeof useTranslations<T>>;

--- a/src/app/api/set-locale/route.ts
+++ b/src/app/api/set-locale/route.ts
@@ -1,0 +1,20 @@
+import { locales } from '@/i18n/config';
+import { NextRequest, NextResponse } from 'next/server';
+
+const COOKIE_NAME = 'user-locale';
+
+export async function POST(req: NextRequest) {
+	const { locale } = await req.json();
+
+	if (!locales.includes(locale)) {
+		return NextResponse.json({ error: 'Invalid locale' }, { status: 400 });
+	}
+
+	const response = NextResponse.json({ success: true });
+	response.cookies.set(COOKIE_NAME, locale, {
+		path: '/',
+		maxAge: 60 * 60 * 24 * 365,
+	});
+
+	return response;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Toaster } from '@/components/ui/sonner';
 import { ThemeProvider } from '@/providers/ThemeProvider';
 import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
-import { getLocale } from 'next-intl/server';
+import { getLocale, getMessages } from 'next-intl/server';
 import { inter } from '../styles/fonts';
 import '../styles/globals.css';
 
@@ -18,10 +18,12 @@ export default async function RootLayout({
 	children: React.ReactNode;
 }>) {
 	const locale = await getLocale();
+	const messages = await getMessages();
+
 	return (
 		<html lang={locale} suppressHydrationWarning>
 			<body className={`${inter.className} antialiased`}>
-				<NextIntlClientProvider>
+				<NextIntlClientProvider locale={locale} messages={messages}>
 					<ThemeProvider
 						attribute='class'
 						defaultTheme='system'

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,35 +1,40 @@
-import type { Metadata } from 'next';
-import '../styles/globals.css';
-import { ThemeProvider } from '@/providers/ThemeProvider';
-import { inter } from '../styles/fonts';
-import { Toaster } from '@/components/ui/sonner';
 import Header from '@/components/Header';
+import { Toaster } from '@/components/ui/sonner';
+import { ThemeProvider } from '@/providers/ThemeProvider';
+import type { Metadata } from 'next';
+import { NextIntlClientProvider } from 'next-intl';
+import { getLocale } from 'next-intl/server';
+import { inter } from '../styles/fonts';
+import '../styles/globals.css';
 
 export const metadata: Metadata = {
 	title: 'OTIB - Protótipo',
 	description: 'Uma implementação inicial do OTIB',
 };
 
-export default function RootLayout({
+export default async function RootLayout({
 	children,
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
+	const locale = await getLocale();
 	return (
-		<html lang='pt-br' suppressHydrationWarning>
+		<html lang={locale} suppressHydrationWarning>
 			<body className={`${inter.className} antialiased`}>
-				<ThemeProvider
-					attribute='class'
-					defaultTheme='system'
-					enableSystem
-					disableTransitionOnChange
-				>
-					<div className='min-h-screen min-w-full p-6'>
-						<Header />
-						{children}
-					</div>
-					<Toaster richColors closeButton />
-				</ThemeProvider>
+				<NextIntlClientProvider>
+					<ThemeProvider
+						attribute='class'
+						defaultTheme='system'
+						enableSystem
+						disableTransitionOnChange
+					>
+						<div className='min-h-screen min-w-full p-6'>
+							<Header />
+							{children}
+						</div>
+						<Toaster richColors closeButton />
+					</ThemeProvider>
+				</NextIntlClientProvider>
 			</body>
 		</html>
 	);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,16 @@
 import { buttonVariants } from '@/components/ui/button';
 import { ibmPlexSans } from '@/styles/fonts';
 import { ClipboardList } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 
 export default function Home() {
+	const t = useTranslations('app.Home');
 	return (
 		<main
 			className={`w-full h-[calc(100dvh-109px-24px)] flex flex-col justify-center items-center gap-8 text-4xl lg:text-5xl font-semibold tracking-tight`}
 		>
-			<h1 className={`${ibmPlexSans.className} text-center`}>
-				Bem vindo ao protótipo do OTIB!
-			</h1>
+			<h1 className={`${ibmPlexSans.className} text-center`}>{t('title')}</h1>
 			<Link
 				className={`${buttonVariants({
 					variant: 'default',
@@ -18,7 +18,7 @@ export default function Home() {
 				href='/form'
 			>
 				<ClipboardList size={24} />
-				Formulário de teste
+				{t('button_cta')}
 			</Link>
 		</main>
 	);

--- a/src/components/FormDebugDialog.tsx
+++ b/src/components/FormDebugDialog.tsx
@@ -11,6 +11,7 @@ import {
 import { buttonVariants } from './ui/button';
 import { Bug, X } from 'lucide-react';
 import { useEffect, useRef } from 'react';
+import { useTranslations } from 'next-intl';
 
 interface FormDebugDialogProps {
 	data: ExampleFormType;
@@ -57,6 +58,8 @@ function formatDataToBeautifulPre(data: ExampleFormType) {
 }
 
 export default function FormDebugDialog({ data }: FormDebugDialogProps) {
+	const t = useTranslations('components.FormDebugDialog');
+
 	function useAnimateOnDataChange(data: ExampleFormType) {
 		const ref = useRef<HTMLButtonElement | null>(null);
 
@@ -84,12 +87,12 @@ export default function FormDebugDialog({ data }: FormDebugDialogProps) {
 				})} w-full transition-colors`}
 			>
 				<Bug className='size-5' />
-				Debugar conteúdo do formulário
+				{t('trigger_text')}
 			</AlertDialogTrigger>
 			<AlertDialogContent className='max-h-[calc(100dvh-32)]'>
 				<AlertDialogHeader>
 					<AlertDialogTitle className='inline-flex text-start justify-between items-center font-extrabold'>
-						Conteúdo enviado do Formulário
+						{t('dialog_title')}
 						<AlertDialogAction
 							className={`${buttonVariants({
 								variant: 'secondary',
@@ -109,7 +112,7 @@ export default function FormDebugDialog({ data }: FormDebugDialogProps) {
 					</div>
 
 					<AlertDialogDescription className='text-primary text-start'>
-						Esta opção está disponível somente em ambiente de desenvolvimento
+						{t('dialog_description')}
 					</AlertDialogDescription>
 				</AlertDialogHeader>
 			</AlertDialogContent>

--- a/src/components/FormStepper.tsx
+++ b/src/components/FormStepper.tsx
@@ -8,7 +8,7 @@ import {
 	StepperTrigger,
 } from '@/components/ui/stepper';
 import { Check } from 'lucide-react';
-import React from 'react';
+import { createElement } from 'react';
 
 interface FormStepperProps {
 	steps: FormStep[];
@@ -29,7 +29,7 @@ export default function FormStepper({ steps, activeStep }: FormStepperProps) {
 							{activeStep && step.number < activeStep ? (
 								<Check />
 							) : step.icon ? (
-								React.createElement(step.icon, {
+								createElement(step.icon, {
 									size: 16,
 								})
 							) : (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,6 +8,7 @@ import otib_logo_dark from '../../public/otib/logo/logo-icon-neg.svg';
 import otib_logo_light from '../../public/otib/logo/logo-icon-pos.svg';
 import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 
 export default function Header() {
 	const { theme } = useTheme();
@@ -23,20 +24,22 @@ export default function Header() {
 	return (
 		<header className='w-full flex flex-col gap-5'>
 			<div className='w-full flex justify-between items-center'>
-				<div className='inline-flex gap-2 justify-start items-center'>
-					{mounted && (
-						<Image
-							src={otib_current_logo}
-							className='h-9 w-fit'
-							alt='OTIB logo'
-						/>
-					)}
-					<h1
-						className={`${ibmPlexSans.className} text-3xl font-semibold lg:text-4xl tracking-tight`}
-					>
-						OTIB
-					</h1>
-				</div>
+				<Link href='/'>
+					<div className='inline-flex gap-2 justify-start items-center hover:opacity-70 cursor-pointer transition-opacity'>
+						{mounted && (
+							<Image
+								src={otib_current_logo}
+								className='h-9 w-fit'
+								alt='OTIB logo'
+							/>
+						)}
+						<h1
+							className={`${ibmPlexSans.className} text-3xl font-semibold lg:text-4xl tracking-tight`}
+						>
+							OTIB
+						</h1>
+					</div>
+				</Link>
 
 				<ModeToggle />
 			</div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,6 +9,7 @@ import otib_logo_light from '../../public/otib/logo/logo-icon-pos.svg';
 import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { LocaleSwitcher } from './LocaleSwitcher';
 
 export default function Header() {
 	const { theme } = useTheme();
@@ -41,7 +42,10 @@ export default function Header() {
 					</div>
 				</Link>
 
-				<ModeToggle />
+				<div className='flex items-center justify-start gap-2'>
+					<LocaleSwitcher />
+					<ModeToggle />
+				</div>
 			</div>
 			<Separator />
 		</header>

--- a/src/components/LocaleSwitcher.tsx
+++ b/src/components/LocaleSwitcher.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Locale, useTranslations } from 'next-intl';
+import { Languages } from 'lucide-react';
+import { LocaleENUM } from '@/i18n/config';
+
+export function LocaleSwitcher() {
+	const t = useTranslations();
+
+	async function handleLocaleChange(locale: Locale) {
+		await fetch('/api/set-locale', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ locale }),
+		});
+
+		setTimeout(() => {
+			window.location.reload();
+		}, 100);
+	}
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button variant='ghost' size='icon'>
+					<Languages className='size-5' />
+					<span className='sr-only'>
+						{t('components.LocaleSwitcher.toggle')}
+					</span>
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align='end'>
+				<DropdownMenuItem onClick={() => handleLocaleChange(LocaleENUM.ptBR)}>
+					🇧🇷 Português
+				</DropdownMenuItem>
+				<DropdownMenuItem onClick={() => handleLocaleChange(LocaleENUM.en)}>
+					🇺🇸 English
+				</DropdownMenuItem>
+				<DropdownMenuItem onClick={() => handleLocaleChange(LocaleENUM.es)}>
+					🇪🇸 Español
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -11,9 +11,11 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { useTranslations } from 'next-intl';
 
 export function ModeToggle() {
 	const { setTheme } = useTheme();
+	const t = useTranslations();
 
 	return (
 		<DropdownMenu>
@@ -21,18 +23,18 @@ export function ModeToggle() {
 				<Button variant='ghost' size='icon'>
 					<Sun className='h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0' />
 					<Moon className='absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100' />
-					<span className='sr-only'>Toggle theme</span>
+					<span className='sr-only'>{t('components.ModeToggle.toggle')}</span>
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align='end'>
 				<DropdownMenuItem onClick={() => setTheme('light')}>
-					Light
+					{t('components.ModeToggle.light')}
 				</DropdownMenuItem>
 				<DropdownMenuItem onClick={() => setTheme('dark')}>
-					Dark
+					{t('components.ModeToggle.dark')}
 				</DropdownMenuItem>
 				<DropdownMenuItem onClick={() => setTheme('system')}>
-					System
+					{t('components.ModeToggle.system')}
 				</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -21,8 +21,8 @@ export function ModeToggle() {
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
 				<Button variant='ghost' size='icon'>
-					<Sun className='h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0' />
-					<Moon className='absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100' />
+					<Sun className='size-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0' />
+					<Moon className='absolute size-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100' />
 					<span className='sr-only'>{t('components.ModeToggle.toggle')}</span>
 				</Button>
 			</DropdownMenuTrigger>

--- a/src/components/NpsSlider.tsx
+++ b/src/components/NpsSlider.tsx
@@ -2,6 +2,7 @@
 
 import { Slider } from '@/components/ui/slider';
 import { cn } from '@/lib/utils';
+import { useTranslations } from 'next-intl';
 
 interface NpsSliderProps {
 	value?: number;
@@ -16,6 +17,7 @@ export default function NpsSlider({
 	hasError,
 	id,
 }: NpsSliderProps) {
+	const t = useTranslations('components.NpsSlider');
 	const labels = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'];
 
 	return (
@@ -39,7 +41,7 @@ export default function NpsSlider({
 					!value ? 'text-muted-foreground text-md animate-pulse' : 'text-xl'
 				}`}
 			>
-				{value ? labels[value - 1] : 'Arraste para definir'}
+				{value ? labels[value - 1] : t('input_placeholder')}
 			</span>
 		</div>
 	);

--- a/src/components/ui/select-with-search.tsx
+++ b/src/components/ui/select-with-search.tsx
@@ -19,6 +19,7 @@ import { cn } from '@/lib/utils';
 import { useMemo, useState } from 'react';
 import { Skeleton } from './skeleton';
 import { Badge } from '@/components/ui/badge';
+import { useTranslations } from 'next-intl';
 
 type Option = {
 	value: string;
@@ -42,14 +43,9 @@ export const SelectWithSearch = ({
 	optional = false,
 	options,
 	value,
+	placeholder,
 	onChangeAction,
 	multiple = false,
-	placeholder = optional
-		? 'Selecione zero ou mais opções'
-		: multiple
-		? 'Selecione pelo menos uma opção'
-		: 'Selecione uma opção',
-
 	hasError,
 	id,
 	loading,
@@ -57,6 +53,14 @@ export const SelectWithSearch = ({
 	const [open, setOpen] = useState(false);
 	const [search, setSearch] = useState('');
 	const selectedValues = Array.isArray(value) ? value : value ? [value] : [];
+	const t = useTranslations('components.SelectWithSearch');
+
+	if (!placeholder)
+		placeholder = optional
+			? t('placeholder.optional')
+			: multiple
+			? t('placeholder.multiple')
+			: t('placeholder.single');
 
 	const filteredOptions = useMemo(() => {
 		if (!search) return options;
@@ -92,11 +96,15 @@ export const SelectWithSearch = ({
 	);
 
 	const selectedSummary = multiple
-		? selectedLabels.length +
-		  ` opç${selectedLabels.length > 1 ? 'ões' : 'ão'} selecionad${
-				selectedLabels.length > 1 ? 'as' : 'a'
-		  }`
+		? t('selection.selected', { count: selectedLabels.length })
 		: selectedLabels[0]?.label;
+
+	const shortSelectedSummary =
+		(selectedSummary ?? '')
+			.split(' ')
+			.slice(1, 3)
+			.join(' ')
+			.replace(/^./, (c) => c.toUpperCase()) + ':';
 
 	return (
 		<div className='space-y-2 overflow-hidden'>
@@ -174,8 +182,7 @@ export const SelectWithSearch = ({
 			{multiple && selectedLabels.length > 0 && (
 				<div className='border-2 border-accent dark:border-accent/50 bg-accent/35 dark:bg-accent/20 rounded-lg lg:bg-transparent lg:border-0 dark:lg:border-0 dark:lg:bg-transparent py-2 px-3 lg:p-0 flex flex-wrap gap-2 items-center max-h-36 lg:max-h-none overflow-y-auto'>
 					<span className='text-accent-foreground/80 text-base'>
-						Opç{selectedLabels.length > 1 ? 'ões' : 'ão'} selecionad
-						{selectedLabels.length > 1 ? 'as' : 'a'}:
+						{shortSelectedSummary}
 					</span>
 					{selectedLabels.map((item) => (
 						<Badge

--- a/src/forms/ExampleForm/ExampleForm.tsx
+++ b/src/forms/ExampleForm/ExampleForm.tsx
@@ -1,22 +1,26 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
-
 import { FormProvider, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { toast } from 'sonner';
 import useMultiStepForm from '@/hooks/use-multistepform';
-import { exampleFormSteps } from './steps';
+import { getExampleFormSteps } from './steps';
 import { z } from 'zod';
 import { useEffect } from 'react';
 import FormStepper from '@/components/FormStepper';
-import { exampleFormSchema } from './schemas/form-general-schema';
 import FormDebugDialog from '@/components/FormDebugDialog';
+import { useTranslations } from 'next-intl';
+import { getExampleFormSchema } from './schemas/form-general-schema';
 
 const STEP_BLOCK_VALIDATION = false;
 const DEV_MODE = true;
 
 export default function ExampleForm() {
+	const t = useTranslations('forms');
+	const exampleFormSteps = getExampleFormSteps(t);
+	const exampleFormSchema = getExampleFormSchema(t);
+
 	const {
 		currentStep,
 		currentStepIndex,
@@ -29,6 +33,7 @@ export default function ExampleForm() {
 	const methods = useForm({
 		resolver: zodResolver(exampleFormSchema),
 		mode: 'onTouched',
+		context: { t },
 		defaultValues: {
 			...Object.keys(exampleFormSchema.shape).reduce(
 				(acc, key) => ({
@@ -44,7 +49,7 @@ export default function ExampleForm() {
 		if (STEP_BLOCK_VALIDATION) {
 			const isValid = await methods.trigger();
 			if (!isValid) {
-				toast.error('Por favor, preencha todos os campos obrigatórios');
+				toast.error(t('common.toast_content_invalid'));
 				return;
 			}
 		}
@@ -57,7 +62,7 @@ export default function ExampleForm() {
 	}
 
 	function onSubmit(values: z.infer<typeof exampleFormSchema>) {
-		toast.success('Form enviado!');
+		toast.success(t('common.toast_submit_success'));
 		console.log(values);
 	}
 
@@ -83,7 +88,7 @@ export default function ExampleForm() {
 								type='button'
 								onClick={() => backStep()}
 							>
-								Voltar
+								{t('common.button_back')}
 							</Button>
 						)}
 
@@ -92,7 +97,7 @@ export default function ExampleForm() {
 							type={isLastStep ? 'submit' : 'button'}
 							onClick={onNextStep}
 						>
-							{isLastStep ? 'Enviar' : 'Avançar'}
+							{isLastStep ? t('common.button_submit') : t('common.button_next')}
 						</Button>
 					</div>
 				</form>

--- a/src/forms/ExampleForm/schemas/form-general-schema.ts
+++ b/src/forms/ExampleForm/schemas/form-general-schema.ts
@@ -1,16 +1,19 @@
 import { z } from 'zod';
-import { profileStepSchema } from './step1-profile-schema';
-import { tripStepSchema } from './step3-trip-schema';
-import { evaluationStepSchema } from './step5-evaluation-schema';
-import { activitiesStepSchema } from './step4-activities-schema';
-import { planningStepSchema } from './step2-planning-schema';
+import { getProfileStepSchema } from './step1-profile-schema';
+import { getTripStepSchema } from './step3-trip-schema';
+import { getActivitiesStepSchema } from './step4-activities-schema';
+import { getEvaluationStepSchema } from './step5-evaluation-schema';
+import { TFunction } from '@/@types/next-intl';
+import { getPlanningStepSchema } from './step2-planning-schema';
 
-export const exampleFormSchema = z.object({
-	...profileStepSchema.shape,
-	...planningStepSchema.shape,
-	...tripStepSchema.shape,
-	...activitiesStepSchema.shape,
-	...evaluationStepSchema.shape,
-});
+export function getExampleFormSchema(t: TFunction<'forms'>) {
+	return z.object({
+		...getProfileStepSchema(t).shape,
+		...getPlanningStepSchema(t).shape,
+		...getTripStepSchema(t).shape, // TODO: ajustar todos os schemas para traduzir em tempo de exec
+		...getActivitiesStepSchema(t).shape,
+		...getEvaluationStepSchema().shape,
+	});
+}
 
-export type ExampleFormType = z.infer<typeof exampleFormSchema>;
+export type ExampleFormType = z.infer<ReturnType<typeof getExampleFormSchema>>;

--- a/src/forms/ExampleForm/schemas/step1-profile-schema.ts
+++ b/src/forms/ExampleForm/schemas/step1-profile-schema.ts
@@ -1,96 +1,91 @@
+import { TFunction } from '@/@types/next-intl';
 import { objectToSelectOptions } from '@/utils/object-to-select-options';
 import { z } from 'zod';
 
-const localizationOptions = {
-	tourist_country: {
-		br: 'Brasil',
-		ar: 'Argentina',
-		de: 'Germany',
-		fr: 'France',
-	},
-	tourist_state: {
-		SP: 'São Paulo',
-		RJ: 'Rio de Janeiro',
-		MG: 'Minas Gerais',
-		RS: 'Rio Grande do Sul',
-	},
-	tourist_city: {
-		sao_paulo: 'São Paulo',
-		rio: 'Rio de Janeiro',
-		bh: 'Belo Horizonte',
-		poa: 'Porto Alegre',
-	},
-} as const;
+export function getProfileStepSchema(t: TFunction<'forms'>) {
+	return z.object({
+		tourist_country: z.string({ required_error: t('errors.field_required') }),
+		tourist_state: z.string({ required_error: t('errors.field_required') }),
+		tourist_city: z.string({ required_error: t('errors.field_required') }),
 
-const personalOptions = {
-	tourist_age_group: {
-		'0': '18 a 24 anos',
-		'1': '25 a 34 anos',
-		'2': '35 a 44 anos',
-		'3': '45 a 54 anos',
-		'4': '55 a 64 anos',
-		'5': '65 anos ou mais',
-	},
-	tourist_gender: {
-		male: 'Masculino',
-		female: 'Feminino',
-		non_binary: 'Não binário',
-		other: 'Outro',
-		omit: 'Prefiro não informar',
-	},
-} as const;
+		tourist_age_group: z.string({ required_error: t('errors.field_required') }),
+		tourist_gender: z.string({ required_error: t('errors.field_required') }),
 
-const improvementOptions = {
-	tourist_education: {
-		'0': 'Ensino fundamental incompleto',
-		'1': 'Ensino fundamental completo',
-		'2': 'Ensino médio incompleto',
-		'3': 'Ensino médio completo',
-		'4': 'Ensino superior incompleto',
-		'5': 'Ensino superior completo',
-	},
-	tourist_estimated_income: {
-		low: 'Menos de R$1.000',
-		low_mid: 'R$1.000 - R$3.000',
-		mid: 'R$3.000 - R$5.000',
-		high_mid: 'R$5.000 - R$10.000',
-		high: 'Mais de R$10.000',
-		omit: 'Prefiro não informar',
-	},
-};
+		tourist_education: z.string({ required_error: t('errors.field_required') }),
+		tourist_estimated_income: z.string({
+			required_error: t('errors.field_required'),
+		}),
+	});
+}
 
-export const profileStepSchema = z.object({
-	tourist_country: z.string({ required_error: 'Campo obrigatório' }),
-	tourist_state: z.string({ required_error: 'Campo obrigatório' }),
-	tourist_city: z.string({ required_error: 'Campo obrigatório' }),
+export function getProfileStepSelectOptions(
+	t: TFunction<'forms.ExampleForm.steps.1.fields'>
+) {
+	const localizationOptions = {
+		tourist_country: {
+			br: 'Brasil',
+			ar: 'Argentina',
+			de: 'Germany',
+			fr: 'France',
+		},
+		tourist_state: {
+			SP: 'São Paulo',
+			RJ: 'Rio de Janeiro',
+			MG: 'Minas Gerais',
+			RS: 'Rio Grande do Sul',
+		},
+		tourist_city: {
+			sao_paulo: 'São Paulo',
+			rio: 'Rio de Janeiro',
+			bh: 'Belo Horizonte',
+			poa: 'Porto Alegre',
+		},
+	} as const; // TODO: fetch de localizações
 
-	tourist_age_group: z.string({ required_error: 'Campo obrigatório' }),
-	tourist_gender: z.string({ required_error: 'Gênero é obrigatório' }),
+	return {
+		localization: {
+			tourist_country: objectToSelectOptions(
+				localizationOptions.tourist_country
+			),
+			tourist_state: objectToSelectOptions(localizationOptions.tourist_state),
+			tourist_city: objectToSelectOptions(localizationOptions.tourist_city),
+		},
+		personal: {
+			tourist_age_group: objectToSelectOptions({
+				'0': t('tourist_age_group.options.0'),
+				'1': t('tourist_age_group.options.1'),
+				'2': t('tourist_age_group.options.2'),
+				'3': t('tourist_age_group.options.3'),
+				'4': t('tourist_age_group.options.4'),
+				'5': t('tourist_age_group.options.5'),
+			}),
+			tourist_gender: objectToSelectOptions({
+				male: t('tourist_gender.options.male'),
+				female: t('tourist_gender.options.female'),
+				non_binary: t('tourist_gender.options.non_binary'),
+				other: t('tourist_gender.options.other'),
+				omit: t('tourist_gender.options.omit'),
+			}),
+		},
+		improvement: {
+			tourist_education: objectToSelectOptions({
+				'0': t('tourist_education.options.0'),
+				'1': t('tourist_education.options.1'),
+				'2': t('tourist_education.options.2'),
+				'3': t('tourist_education.options.3'),
+				'4': t('tourist_education.options.4'),
+				'5': t('tourist_education.options.5'),
+			}),
+			tourist_estimated_income: objectToSelectOptions({
+				low: t('tourist_estimated_income.options.low'),
+				low_mid: t('tourist_estimated_income.options.low_mid'),
+				mid: t('tourist_estimated_income.options.mid'),
+				high_mid: t('tourist_estimated_income.options.high_mid'),
+				high: t('tourist_estimated_income.options.high'),
+				omit: t('tourist_estimated_income.options.omit'),
+			}),
+		},
+	};
+}
 
-	tourist_education: z.string({ required_error: 'Campo obrigatório' }),
-	tourist_estimated_income: z.string({
-		required_error: 'Campo obrigatório',
-	}),
-});
-
-export const profileStepSelectOptions = {
-	localization: {
-		tourist_country: objectToSelectOptions(localizationOptions.tourist_country),
-		tourist_state: objectToSelectOptions(localizationOptions.tourist_state),
-		tourist_city: objectToSelectOptions(localizationOptions.tourist_city),
-	},
-	personal: {
-		tourist_age_group: objectToSelectOptions(personalOptions.tourist_age_group),
-		tourist_gender: objectToSelectOptions(personalOptions.tourist_gender),
-	},
-	improvement: {
-		tourist_education: objectToSelectOptions(
-			improvementOptions.tourist_education
-		),
-		tourist_estimated_income: objectToSelectOptions(
-			improvementOptions.tourist_estimated_income
-		),
-	},
-};
-
-export type ProfileStepType = z.infer<typeof profileStepSchema>;
+export type ProfileStepType = z.infer<ReturnType<typeof getProfileStepSchema>>;

--- a/src/forms/ExampleForm/schemas/step2-planning-schema.ts
+++ b/src/forms/ExampleForm/schemas/step2-planning-schema.ts
@@ -1,44 +1,49 @@
+import { TFunction } from '@/@types/next-intl';
 import { objectToSelectOptions } from '@/utils/object-to-select-options';
 import { z } from 'zod';
 
-const planningTimeOptions = {
-	'0': 'Menos de 1 mês',
-	'1': '1 a 3 meses',
-	'2': '3 a 6 meses',
-	'3': 'Mais de 6 meses',
-} as const;
+export function getPlanningStepSchema(t: TFunction<'forms'>) {
+	return z.object({
+		planning_was_planned: z.boolean({
+			required_error: t('errors.field_required'),
+		}),
+		planning_time: z.string().optional(),
+		planning_information_sources: z.array(z.string()).optional(),
+		planning_organization: z.string({
+			required_error: t('errors.field_required'),
+		}),
+	});
+}
 
-const informationSourcesOptions = {
-	'0': 'Sites de viagem',
-	'1': 'Redes sociais',
-	'2': 'Recomendações de amigos',
-	'3': 'Agências de viagem',
-	'4': 'Guias impressos',
-	'5': 'Outro',
-} as const;
+export function getPlanningStepSelectOptions(
+	t: TFunction<'forms.ExampleForm.steps.2.fields'>
+) {
+	return {
+		planning_time: objectToSelectOptions({
+			'0': t('planning_time.options.0'),
+			'1': t('planning_time.options.1'),
+			'2': t('planning_time.options.2'),
+			'3': t('planning_time.options.3'),
+		}),
+		planning_information_sources: objectToSelectOptions({
+			'0': t('planning_information_sources.options.0'),
+			'1': t('planning_information_sources.options.1'),
+			'2': t('planning_information_sources.options.2'),
+			'3': t('planning_information_sources.options.3'),
+			'4': t('planning_information_sources.options.4'),
+			'5': t('planning_information_sources.options.5'),
+		}),
+		planning_organization: objectToSelectOptions({
+			'0': t('planning_organization.options.0'),
+			'1': t('planning_organization.options.1'),
+			'2': t('planning_organization.options.2'),
+			'3': t('planning_organization.options.3'),
+			'4': t('planning_organization.options.4'),
+			'5': t('planning_organization.options.5'),
+		}),
+	};
+}
 
-const organizationOptions = {
-	'0': 'Viagem individual',
-	'1': 'Viagem em casal',
-	'2': 'Viagem em família',
-	'3': 'Viagem em grupo',
-	'4': 'Com agência de viagens',
-	'5': 'Outro',
-} as const;
-
-export const planningStepSchema = z.object({
-	planning_was_planned: z.boolean({ required_error: 'Campo obrigatório' }),
-	planning_time: z.string().optional(),
-	planning_information_sources: z.array(z.string()).optional(),
-	planning_organization: z.string({ required_error: 'Campo obrigatório' }),
-});
-
-export const planningStepSelectOptions = {
-	planning_time: objectToSelectOptions(planningTimeOptions),
-	planning_information_sources: objectToSelectOptions(
-		informationSourcesOptions
-	),
-	planning_organization: objectToSelectOptions(organizationOptions),
-};
-
-export type PlanningStepType = z.infer<typeof planningStepSchema>;
+export type PlanningStepType = z.infer<
+	ReturnType<typeof getPlanningStepSchema>
+>;

--- a/src/forms/ExampleForm/schemas/step3-trip-schema.ts
+++ b/src/forms/ExampleForm/schemas/step3-trip-schema.ts
@@ -1,147 +1,127 @@
+import { TFunction } from '@/@types/next-intl';
 import { objectToSelectOptions } from '@/utils/object-to-select-options';
 import { z } from 'zod';
 
-const tripReasonsOptions = {
-	'0': 'Lazer, Passeios/Descanso', //  (aqui seria interessante abrir para perguntar a principal motivação (aventura, atrativos naturais, cultura, gastronomia, religião, rural, eventos..)
-	'1': 'Negócios/Trabalho',
-	'2': 'Visita a Parentes/Amigos',
-	'3': 'Educação, Cursos, Qualificação',
-	'4': 'Esportes',
-	'5': 'Compras',
-	'6': 'Serviços médicos',
-	'7': 'Religioso',
-	'8': 'Outros',
-} as const;
+export function getTripStepSchema(t: TFunction<'forms'>) {
+	return z.object({
+		trip_has_reincidence: z.boolean({
+			required_error: t('errors.field_required'),
+		}),
+		trip_reincidence: z.string().optional(),
+		trip_know_ibiapaba_mirantes: z.boolean({
+			required_error: t('errors.field_required'),
+		}),
+		trip_how_know_ibiapaba_mirantes: z
+			.array(z.string(), {
+				required_error: t('errors.field_require_at_least_one'),
+			})
+			.optional(),
 
-const tripVehiclesOptions = {
-	'0': 'Carro próprio',
-	'1': 'Ônibus',
-	'2': 'Moto',
-	'3': 'Bicicleta',
-	'4': 'Van',
-	'5': 'Transporte por aplicativo (Ubis, Mototáxi Tianguá, etc.)',
-	'6': 'Táxi',
-	'7': 'Motorhome/Trailer',
-	'8': 'Avião',
-	'9': 'Outro',
-} as const;
+		trip_reasons: z
+			.array(z.string(), {
+				required_error: t('errors.field_require_at_least_one'),
+			})
+			.min(1, { message: t('errors.field_require_at_least_one') }),
+		trip_vehicles: z
+			.array(z.string(), {
+				required_error: t('errors.field_require_at_least_one'),
+			})
+			.min(1, { message: t('errors.field_require_at_least_one') }),
+		trip_stay_time: z.string({
+			required_error: t('errors.field_required'),
+		}),
 
-const tripStayTimeOptions = {
-	'0': '1 dia',
-	'1': '2 a 3 dias',
-	'2': 'Apenas no final de semana',
-	'3': '4 dias',
-	'4': '5 dias',
-	'5': '1 semana',
-	'6': '15 dias',
-	'7': 'Mais de 15 dias',
-} as const;
+		trip_average_diary_expense: z.string({
+			required_error: t('errors.field_required'),
+		}),
+		trip_hosting_types: z
+			.array(z.string(), {
+				required_error: t('errors.field_require_at_least_one'),
+			})
+			.min(1, { message: t('errors.field_require_at_least_one') }),
+	});
+}
 
-const tripReincidenceOptions = {
-	'0': 'Já visitei entre 2 e 5 vezes',
-	'1': 'Já visitei entre 5 e 10 vezes',
-	'2': 'Já visitei mais de 10 vezes',
-	'3': 'Visito uma vez por mês',
-	'4': 'Visito a cada fim de semana',
-} as const;
+export function getTripStepSelectOptions(
+	t: TFunction<'forms.ExampleForm.steps.3.fields'>
+) {
+	return {
+		trip_reincidence: objectToSelectOptions({
+			'0': t('trip_reincidence.options.0'),
+			'1': t('trip_reincidence.options.1'),
+			'2': t('trip_reincidence.options.2'),
+			'3': t('trip_reincidence.options.3'),
+			'4': t('trip_reincidence.options.4'),
+		}),
+		trip_how_know_ibiapaba_mirantes: objectToSelectOptions({
+			'0': t('trip_how_know_ibiapaba_mirantes.options.0'),
+			'1': t('trip_how_know_ibiapaba_mirantes.options.1'),
+			'2': t('trip_how_know_ibiapaba_mirantes.options.2'),
+			'3': t('trip_how_know_ibiapaba_mirantes.options.3'),
+			'4': t('trip_how_know_ibiapaba_mirantes.options.4'),
+			'5': t('trip_how_know_ibiapaba_mirantes.options.5'),
+			'6': t('trip_how_know_ibiapaba_mirantes.options.6'),
+			'7': t('trip_how_know_ibiapaba_mirantes.options.7'),
+			'8': t('trip_how_know_ibiapaba_mirantes.options.8'),
+			'9': t('trip_how_know_ibiapaba_mirantes.options.9'),
+			'10': t('trip_how_know_ibiapaba_mirantes.options.10'),
+			'11': t('trip_how_know_ibiapaba_mirantes.options.11'),
+		}),
+		trip_reasons: objectToSelectOptions({
+			'0': t('trip_how_know_ibiapaba_mirantes.options.0'), // no caso de 'Lazer, Passeios/Descanso' -> (aqui seria interessante abrir para perguntar a principal motivação (aventura, atrativos naturais, cultura, gastronomia, religião, rural, eventos..)
+			'1': t('trip_how_know_ibiapaba_mirantes.options.1'),
+			'2': t('trip_how_know_ibiapaba_mirantes.options.2'),
+			'3': t('trip_how_know_ibiapaba_mirantes.options.3'),
+			'4': t('trip_how_know_ibiapaba_mirantes.options.4'),
+			'5': t('trip_how_know_ibiapaba_mirantes.options.5'),
+			'6': t('trip_how_know_ibiapaba_mirantes.options.6'),
+			'7': t('trip_how_know_ibiapaba_mirantes.options.7'),
+			'8': t('trip_how_know_ibiapaba_mirantes.options.8'),
+		}),
+		trip_stay_time: objectToSelectOptions({
+			'0': t('trip_stay_time.options.0'),
+			'1': t('trip_stay_time.options.1'),
+			'2': t('trip_stay_time.options.2'),
+			'3': t('trip_stay_time.options.3'),
+			'4': t('trip_stay_time.options.4'),
+			'5': t('trip_stay_time.options.5'),
+			'6': t('trip_stay_time.options.6'),
+			'7': t('trip_stay_time.options.7'),
+		}),
+		trip_vehicles: objectToSelectOptions({
+			'0': t('trip_vehicles.options.0'),
+			'1': t('trip_vehicles.options.1'),
+			'2': t('trip_vehicles.options.2'),
+			'3': t('trip_vehicles.options.3'),
+			'4': t('trip_vehicles.options.4'),
+			'5': t('trip_vehicles.options.5'),
+			'6': t('trip_vehicles.options.6'),
+			'7': t('trip_vehicles.options.7'),
+			'8': t('trip_vehicles.options.8'),
+		}),
+		trip_average_diary_expense: objectToSelectOptions({
+			'0': t('trip_average_diary_expense.options.0'),
+			'1': t('trip_average_diary_expense.options.1'),
+			'2': t('trip_average_diary_expense.options.2'),
+			'3': t('trip_average_diary_expense.options.3'),
+			'4': t('trip_average_diary_expense.options.4'),
+			'5': t('trip_average_diary_expense.options.5'),
+			'6': t('trip_average_diary_expense.options.6'),
+			'7': t('trip_average_diary_expense.options.7'),
+		}),
+		trip_hosting_types: objectToSelectOptions({
+			'0': t('trip_hosting_types.options.0'),
+			'1': t('trip_hosting_types.options.1'),
+			'2': t('trip_hosting_types.options.2'),
+			'3': t('trip_hosting_types.options.3'),
+			'4': t('trip_hosting_types.options.4'),
+			'5': t('trip_hosting_types.options.5'),
+			'6': t('trip_hosting_types.options.6'),
+			'7': t('trip_hosting_types.options.7'),
+			'8': t('trip_hosting_types.options.8'),
+			'9': t('trip_hosting_types.options.9'),
+		}),
+	};
+}
 
-const tripHowKnowMirantes = {
-	'0': 'Rádio',
-	'1': 'TV',
-	'2': 'Revistas e jornais',
-	'3': 'Agências de viagens',
-	'4': 'Google e buscadores em geral',
-	'5': 'Redes sociais (Facebook, Instagram, outros)',
-	'6': 'Site Experiências Ibiapaba',
-	'7': 'Site dos municípios',
-	'8': 'Sites de reserva online (OTA, como Booking, decolar)',
-	'9': 'Sites especializados em turismo',
-	'10': 'Blogs de viagens',
-	'11': 'Outros',
-} as const;
-
-const tripHostingTypesOptions = {
-	'0': 'Hotel',
-	'1': 'Pousada',
-	'2': 'Casa de familiares/amigos',
-	'3': 'Aluguel por temporada',
-	'4': 'Camping',
-	'5': 'Hostel',
-	'6': 'Resort',
-	'7': 'Chalé',
-	'8': 'Motorhome/Trailer',
-	'9': 'Outro',
-} as const;
-
-const tripDiaryExpenseOptions = {
-	'0': 'Até R$ 300,00',
-	'1': 'De R$ 300,00 a R$ 500,00',
-	'2': 'De R$ 500,00 a R$ 1.000,00',
-	'3': 'De R$ 1.000,00 a R$ 1.500,00',
-	'4': 'De R$ 1.500,00 a R$ 2.000,00',
-	'5': 'De R$ 2.000,00 a R$ 3.000,00',
-	'6': 'De R$ 3.000,00 a R$ 5.000,00',
-	'7': 'Acima de R$ 5.000,00',
-} as const;
-
-export const tripStepSchema = z.object({
-	trip_has_reincidence: z.boolean({ required_error: 'Campo obrigatório' }),
-	trip_reincidence: z.string().optional(),
-	trip_know_ibiapaba_mirantes: z.boolean({
-		required_error: 'Campo obrigatório',
-	}),
-	trip_how_know_ibiapaba_mirantes: z
-		.array(z.string(), {
-			required_error: 'Selecione pelo menos 1 opção',
-		})
-		.optional(),
-	/*
-		Para quem responder SIM, abrir nova pergunta com: Como ficou sabendo:
-		Opções de resposta:
-			a) Rádio
-			b) TV
-			c) Revistas e jornais
-			d) Agências de viagens
-			e) Google e buscadores em geral
-			f) Redes sociais (Facebook, Instagram, outros)
-			g) Site Experiências Ibiapaba
-			h) Site dos municípios
-			i) Sites de reserva online (OTA, como Booking, decolar)
-			j) Sites especializados em turismo
-			k) Blogs de viagens
-			l) Outros. Especificar
-	*/ trip_reasons: z
-		.array(z.string(), {
-			required_error: 'Selecione pelo menos 1 opção',
-		})
-		.min(1, { message: 'Selecione pelo menos 1 opção' }),
-	trip_vehicles: z
-		.array(z.string(), {
-			required_error: 'Selecione pelo menos 1 opção',
-		})
-		.min(1, { message: 'Selecione pelo menos 1 opção' }),
-	trip_stay_time: z.string({
-		required_error: 'Campo obrigatório',
-	}),
-
-	trip_average_diary_expense: z.string({
-		required_error: 'Campo obrigatório',
-	}),
-	trip_hosting_types: z
-		.array(z.string(), {
-			required_error: 'Selecione pelo menos 1 opção',
-		})
-		.min(1, { message: 'Selecione pelo menos 1 opção' }),
-});
-
-export const tripStepSelectOptions = {
-	trip_reasons: objectToSelectOptions(tripReasonsOptions),
-	trip_reincidence: objectToSelectOptions(tripReincidenceOptions),
-	trip_how_know_ibiapaba_mirantes: objectToSelectOptions(tripHowKnowMirantes),
-	trip_vehicles: objectToSelectOptions(tripVehiclesOptions),
-	trip_hosting_types: objectToSelectOptions(tripHostingTypesOptions),
-	trip_stay_time: objectToSelectOptions(tripStayTimeOptions),
-	trip_average_diary_expense: objectToSelectOptions(tripDiaryExpenseOptions),
-};
-
-export type TripStepType = z.infer<typeof tripStepSchema>;
+export type TripStepType = z.infer<ReturnType<typeof getTripStepSchema>>;

--- a/src/forms/ExampleForm/schemas/step4-activities-schema.ts
+++ b/src/forms/ExampleForm/schemas/step4-activities-schema.ts
@@ -1,47 +1,52 @@
+import { TFunction } from '@/@types/next-intl';
 import { objectToSelectOptions } from '@/utils/object-to-select-options';
 import { z } from 'zod';
 
-const placesVisitedOptions = {
-	'0': 'Carnaubal',
-	'1': 'Croatá',
-	'2': 'Guaraciaba do Norte',
-	'3': 'Ibiapina',
-	'4': 'Ipu',
-	'5': 'São Benedito',
-	'6': 'Tianguá',
-	'7': 'Ubajara',
-	'8': 'Viçosa do Ceará',
-} as const;
+export function getActivitiesStepSchema(t: TFunction<'forms'>) {
+	return z.object({
+		activities_places_visited: z
+			.array(z.string(), {
+				required_error: t('errors.field_require_custom', { count: 3 }),
+			})
+			.min(3, { message: t('errors.field_require_custom', { count: 3 }) }),
+		activities_events_visited: z.array(z.string()).optional(),
+		activities_used_apps: z.array(z.string()).optional(),
+	});
+}
 
-const eventsVisitedOption = {
-	'0': 'Museus',
-	'1': 'Espaços religiosos (igrejas, festejos)',
-	'2': 'Atividades de aventura na natureza',
-	'3': 'Parques temáticos',
-} as const;
+export function getActivitiesStepSelectOptions(
+	t: TFunction<'forms.ExampleForm.steps.4.fields'>
+) {
+	return {
+		activities_places_visited: objectToSelectOptions({
+			'0': 'Carnaubal',
+			'1': 'Croatá',
+			'2': 'Guaraciaba do Norte',
+			'3': 'Ibiapina',
+			'4': 'Ipu',
+			'5': 'São Benedito',
+			'6': 'Tianguá',
+			'7': 'Ubajara',
+			'8': 'Viçosa do Ceará',
+		}),
+		activities_events_visited: objectToSelectOptions({
+			'0': t('activities_events_visited.options.0'),
+			'1': t('activities_events_visited.options.1'),
+			'2': t('activities_events_visited.options.2'),
+			'3': t('activities_events_visited.options.3'),
+		}),
+		activities_used_apps: objectToSelectOptions({
+			'0': t('activities_used_apps.options.0'),
+			'1': t('activities_used_apps.options.1'),
+			'2': t('activities_used_apps.options.2'),
+			'3': t('activities_used_apps.options.3'),
+			'4': t('activities_used_apps.options.4'),
+			'5': t('activities_used_apps.options.5'),
+			'6': t('activities_used_apps.options.6'),
+		}),
+	};
+}
 
-const usedAppsOption = {
-	'0': 'Mapas ou navegadores: Waze, Google Maps, etc.',
-	'1': 'Guias turísticos digitais',
-	'2': 'Tradutores de idiomas',
-	'3': 'Aplicativos de transporte: Uber, 99, etc.',
-	'4': 'Redes sociais para compartilhar experiências',
-	'5': 'Aplicativos de reserva de hospedagem: Booking, Airbnb, etc.',
-	'6': 'Aplicativos de avaliação de restaurantes e atrações: TripAdvisor, Google Avaliações, etc.',
-} as const;
-
-export const activitiesStepSchema = z.object({
-	activities_places_visited: z
-		.array(z.string(), { required_error: 'Selecione pelo menos 3 destinos' })
-		.min(3, { message: 'Selecione pelo menos 3 destinos' }),
-	activities_events_visited: z.array(z.string()).optional(),
-	activities_used_apps: z.array(z.string()).optional(),
-});
-
-export type ActivitiesStepType = z.infer<typeof activitiesStepSchema>;
-
-export const activitiesStepSelectOptions = {
-	activities_places_visited: objectToSelectOptions(placesVisitedOptions),
-	activities_events_visited: objectToSelectOptions(eventsVisitedOption),
-	activities_used_apps: objectToSelectOptions(usedAppsOption),
-};
+export type ActivitiesStepType = z.infer<
+	ReturnType<typeof getActivitiesStepSchema>
+>;

--- a/src/forms/ExampleForm/schemas/step5-evaluation-schema.ts
+++ b/src/forms/ExampleForm/schemas/step5-evaluation-schema.ts
@@ -1,3 +1,4 @@
+import { TFunction } from '@/@types/next-intl';
 import { objectToSelectOptions } from '@/utils/object-to-select-options';
 import { z } from 'zod';
 
@@ -21,48 +22,54 @@ import { z } from 'zod';
 // 	'4': 'Decepcionou',
 // } as const;
 
-const dissatisfactionOptions = {
-	'0': 'Limpeza',
-	'1': 'Sinalização das ruas',
-	'2': 'Sinalização turística',
-	'3': 'Conservação das ruas e mobiliário urbano',
-	'4': 'Rodovia de acesso',
-	'5': 'Estacionamento',
-	'6': 'Táxi',
-	'7': 'Mobilidade/Transporte',
-	'8': 'Bancos/caixas eletrônicos',
-	'9': 'Segurança',
-	'10': 'Iluminação',
-	'11': 'Preços',
-	'12': 'Site institucional',
-	'13': 'Hospitalidade dos moradores',
-	'14': 'Hospitalidade dos prestadores de serviços e comércio',
-	'15': 'Receptivo',
-	'16': 'Hospedagem',
-	'17': 'Restaurantes/gastronomia',
-	'18': 'Guia de turismo/Condutor ambiental',
-	'19': 'Artesanato',
-	'20': 'Comércio em geral',
-	'21': 'Manifestações culturais',
-	'22': 'Atrativos naturais',
-	'23': 'Eventos',
-	'24': 'Opções de lazer',
-	'25': 'Diversões noturnas',
-} as const;
+export function getEvaluationStepSchema() {
+	return z.object({
+		evaluation_recommendation_rate: z.number().min(1).max(10).optional(),
+		evaluation_dissatisfactions: z.array(z.string()).optional(),
 
-export const evaluationStepSchema = z.object({
-	evaluation_recommendation_rate: z.number().min(1).max(10).optional(),
-	evaluation_dissatisfactions: z.array(z.string()).optional(),
+		evaluation_expectation_rate: z.number().min(1).max(10).optional(),
+		evaluation_satisfaction_rate: z.number().min(1).max(10).optional(),
 
-	evaluation_expectation_rate: z.number().min(1).max(10).optional(),
-	evaluation_satisfaction_rate: z.number().min(1).max(10).optional(),
+		evaluation_return_intent_rate: z.number().min(1).max(10).optional(),
+		evaluation_open_opinion: z.string().max(1000).optional(),
+	});
+}
 
-	evaluation_return_intent_rate: z.number().min(1).max(10).optional(),
-	evaluation_open_opinion: z.string().max(1000).optional(),
-});
+export function getEvaluationStepSelectOptions(
+	t: TFunction<'forms.ExampleForm.steps.5.fields'>
+) {
+	return {
+		evaluation_dissatisfactions: objectToSelectOptions({
+			'0': t('evaluation_dissatisfactions.options.0'),
+			'1': t('evaluation_dissatisfactions.options.1'),
+			'2': t('evaluation_dissatisfactions.options.2'),
+			'3': t('evaluation_dissatisfactions.options.3'),
+			'4': t('evaluation_dissatisfactions.options.4'),
+			'5': t('evaluation_dissatisfactions.options.5'),
+			'6': t('evaluation_dissatisfactions.options.6'),
+			'7': t('evaluation_dissatisfactions.options.7'),
+			'8': t('evaluation_dissatisfactions.options.8'),
+			'9': t('evaluation_dissatisfactions.options.9'),
+			'10': t('evaluation_dissatisfactions.options.10'),
+			'11': t('evaluation_dissatisfactions.options.11'),
+			'12': t('evaluation_dissatisfactions.options.12'),
+			'13': t('evaluation_dissatisfactions.options.13'),
+			'14': t('evaluation_dissatisfactions.options.14'),
+			'15': t('evaluation_dissatisfactions.options.15'),
+			'16': t('evaluation_dissatisfactions.options.16'),
+			'17': t('evaluation_dissatisfactions.options.17'),
+			'18': t('evaluation_dissatisfactions.options.18'),
+			'19': t('evaluation_dissatisfactions.options.19'),
+			'20': t('evaluation_dissatisfactions.options.20'),
+			'21': t('evaluation_dissatisfactions.options.21'),
+			'22': t('evaluation_dissatisfactions.options.22'),
+			'23': t('evaluation_dissatisfactions.options.23'),
+			'24': t('evaluation_dissatisfactions.options.24'),
+			'25': t('evaluation_dissatisfactions.options.25'),
+		}),
+	};
+}
 
-export const evaluationStepSelectOptions = {
-	evaluation_dissatisfactions: objectToSelectOptions(dissatisfactionOptions),
-};
-
-export type EvaluationStepType = z.infer<typeof evaluationStepSchema>;
+export type EvaluationStepType = z.infer<
+	ReturnType<typeof getEvaluationStepSchema>
+>;

--- a/src/forms/ExampleForm/steps.ts
+++ b/src/forms/ExampleForm/steps.ts
@@ -1,49 +1,53 @@
 import { FormStep } from '@/@types/form-step';
 import TouristStep from './steps/step1-profile';
 import { Activity, Percent, Plane, Route, User } from 'lucide-react';
-import { profileStepSchema } from './schemas/step1-profile-schema';
-import { tripStepSchema } from './schemas/step3-trip-schema';
+import { getProfileStepSchema } from './schemas/step1-profile-schema';
+import { getTripStepSchema } from './schemas/step3-trip-schema';
 import ActivitiesStep from './steps/step4-activities';
 import EvaluationStep from './steps/step5-evaluation';
-import { activitiesStepSchema } from './schemas/step4-activities-schema';
-import { evaluationStepSchema } from './schemas/step5-evaluation-schema';
+import { getActivitiesStepSchema } from './schemas/step4-activities-schema';
+import { getEvaluationStepSchema } from './schemas/step5-evaluation-schema';
 import TripStep from './steps/step3-trip';
 import PlanningStep from './steps/step2-planning';
+import { TFunction } from '@/@types/next-intl';
+import { getPlanningStepSchema } from './schemas/step2-planning-schema';
 
-export const exampleFormSteps: Array<FormStep> = [
-	{
-		number: 1,
-		title: 'Você',
-		step: TouristStep,
-		schema: profileStepSchema,
-		icon: User,
-	},
-	{
-		number: 2,
-		title: 'Planos',
-		step: PlanningStep,
-		schema: profileStepSchema,
-		icon: Route,
-	},
-	{
-		number: 3,
-		title: 'Viagem',
-		step: TripStep,
-		schema: tripStepSchema,
-		icon: Plane,
-	},
-	{
-		number: 4,
-		title: 'Atividades',
-		step: ActivitiesStep,
-		schema: activitiesStepSchema,
-		icon: Activity,
-	},
-	{
-		number: 5,
-		title: 'Avaliação',
-		step: EvaluationStep,
-		schema: evaluationStepSchema,
-		icon: Percent,
-	},
-];
+export function getExampleFormSteps(t: TFunction<'forms'>): Array<FormStep> {
+	return [
+		{
+			number: 1,
+			title: t('ExampleForm.steps.1.title'),
+			step: TouristStep,
+			schema: getProfileStepSchema(t),
+			icon: User,
+		},
+		{
+			number: 2,
+			title: t('ExampleForm.steps.2.title'),
+			step: PlanningStep,
+			schema: getPlanningStepSchema(t),
+			icon: Route,
+		},
+		{
+			number: 3,
+			title: t('ExampleForm.steps.3.title'),
+			step: TripStep,
+			schema: getTripStepSchema(t),
+			icon: Plane,
+		},
+		{
+			number: 4,
+			title: t('ExampleForm.steps.4.title'),
+			step: ActivitiesStep,
+			schema: getActivitiesStepSchema(t),
+			icon: Activity,
+		},
+		{
+			number: 5,
+			title: t('ExampleForm.steps.5.title'),
+			step: EvaluationStep,
+			schema: getEvaluationStepSchema(),
+			icon: Percent,
+		},
+	];
+}

--- a/src/forms/ExampleForm/steps/step1-profile.tsx
+++ b/src/forms/ExampleForm/steps/step1-profile.tsx
@@ -1,16 +1,15 @@
 import { Separator } from '@/components/ui/separator';
 import { FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Controller, useFormContext } from 'react-hook-form';
-import {
-	profileStepSelectOptions,
-	ProfileStepType,
-} from '../schemas/step1-profile-schema';
+import { getProfileStepSelectOptions, ProfileStepType } from '../schemas/step1-profile-schema';
 import { SelectWithSearch } from '@/components/ui/select-with-search';
+import { useTranslations } from 'next-intl';
 
 export default function ProfileStep() {
+	const t = useTranslations('forms.ExampleForm.steps.1.fields');
+	const profileStepSelectOptions = getProfileStepSelectOptions(t)
 	const {
 		control,
-		// register, -> register para inputs, control para selects
 		formState: { errors },
 	} = useFormContext<ProfileStepType>();
 
@@ -23,7 +22,7 @@ export default function ProfileStep() {
 						aria-invalid={!!errors.tourist_country}
 						aria-required
 					>
-						País
+						{t('tourist_country.form_label')}
 					</FormLabel>
 					<Controller
 						name='tourist_country'
@@ -49,7 +48,7 @@ export default function ProfileStep() {
 						aria-invalid={!!errors.tourist_state}
 						aria-required
 					>
-						Estado
+						{t('tourist_state.form_label')}
 					</FormLabel>
 					<Controller
 						name='tourist_state'
@@ -75,7 +74,7 @@ export default function ProfileStep() {
 						aria-invalid={!!errors.tourist_city}
 						aria-required
 					>
-						Cidade
+						{t('tourist_city.form_label')}
 					</FormLabel>
 					<Controller
 						name='tourist_city'
@@ -105,7 +104,7 @@ export default function ProfileStep() {
 						aria-invalid={!!errors.tourist_age_group}
 						aria-required
 					>
-						Faixa etária
+						{t('tourist_age_group.form_label')}
 					</FormLabel>
 					<Controller
 						name='tourist_age_group'
@@ -133,7 +132,7 @@ export default function ProfileStep() {
 						aria-invalid={!!errors.tourist_gender}
 						aria-required
 					>
-						Gênero
+						{t('tourist_gender.form_label')}
 					</FormLabel>
 					<Controller
 						name='tourist_gender'
@@ -163,7 +162,7 @@ export default function ProfileStep() {
 						aria-invalid={!!errors.tourist_education}
 						aria-required
 					>
-						Escolaridade
+						{t('tourist_education.form_label')}
 					</FormLabel>
 					<Controller
 						name='tourist_education'
@@ -191,7 +190,7 @@ export default function ProfileStep() {
 						aria-invalid={!!errors.tourist_estimated_income}
 						aria-required
 					>
-						Renda estimada
+						{t('tourist_estimated_income.form_label')}
 					</FormLabel>
 					<Controller
 						name='tourist_estimated_income'

--- a/src/forms/ExampleForm/steps/step2-planning.tsx
+++ b/src/forms/ExampleForm/steps/step2-planning.tsx
@@ -9,15 +9,17 @@ import { SelectWithSearch } from '@/components/ui/select-with-search';
 import { Separator } from '@/components/ui/separator';
 import {
 	PlanningStepType,
-	planningStepSelectOptions,
+	getPlanningStepSelectOptions,
 } from '../schemas/step2-planning-schema';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { useTranslations } from 'next-intl';
 
 export default function PlanningStep() {
+	const t = useTranslations('forms.ExampleForm.steps.2.fields');
+	const planningStepSelectOptions = getPlanningStepSelectOptions(t);
 	const {
 		control,
 		watch,
-		// register, -> register para inputs, control para selects
 		formState: { errors },
 	} = useFormContext<PlanningStepType>();
 
@@ -35,7 +37,7 @@ export default function PlanningStep() {
 									aria-invalid={!!errors.planning_was_planned}
 									aria-required
 								>
-									Sua viagem foi planejada?
+									{t('planning_was_planned.form_label')}
 								</FormLabel>
 								<FormControl>
 									<RadioGroup
@@ -49,7 +51,7 @@ export default function PlanningStep() {
 												<RadioGroupItem className='size-5' value='true' />
 											</FormControl>
 											<FormLabel className='font-normal text-base'>
-												Sim
+												{t('planning_was_planned.options.radio_true')}
 											</FormLabel>
 										</FormItem>
 										<FormItem className='flex items-center'>
@@ -57,7 +59,7 @@ export default function PlanningStep() {
 												<RadioGroupItem className='size-5' value='false' />
 											</FormControl>
 											<FormLabel className='font-normal text-base'>
-												Não
+												{t('planning_was_planned.options.radio_false')}
 											</FormLabel>
 										</FormItem>
 									</RadioGroup>
@@ -80,7 +82,7 @@ export default function PlanningStep() {
 								htmlFor='planning_time'
 								aria-invalid={!!errors.planning_time}
 							>
-								Com quanto tempo de antecedência sua viagem foi planejada?
+								{t('planning_time.form_label')}
 							</FormLabel>
 
 							<Controller
@@ -108,7 +110,7 @@ export default function PlanningStep() {
 								htmlFor='planning_information_sources'
 								aria-invalid={!!errors.planning_information_sources}
 							>
-								Quais fontes de informação você utilizou para o planejamento?
+								{t('planning_information_sources.form_label')}
 							</FormLabel>
 
 							<Controller
@@ -146,7 +148,7 @@ export default function PlanningStep() {
 					aria-invalid={!!errors.planning_organization}
 					aria-required
 				>
-					Como sua viagem foi organizada?
+					{t('planning_organization.form_label')}
 				</FormLabel>
 
 				<Controller

--- a/src/forms/ExampleForm/steps/step3-trip.tsx
+++ b/src/forms/ExampleForm/steps/step3-trip.tsx
@@ -1,7 +1,7 @@
 import { SelectWithSearch } from '@/components/ui/select-with-search';
 import { Controller, useFormContext } from 'react-hook-form';
 import {
-	tripStepSelectOptions,
+	getTripStepSelectOptions,
 	TripStepType,
 } from '../schemas/step3-trip-schema';
 import {
@@ -12,18 +12,20 @@ import {
 } from '@/components/ui/form';
 import { Separator } from '@/components/ui/separator';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { useTranslations } from 'next-intl';
 
 export default function TripStep() {
+	const t = useTranslations('forms.ExampleForm.steps.3.fields');
+	const tripStepSelectOptions = getTripStepSelectOptions(t);
 	const {
 		control,
 		watch,
-		// register, -> register para inputs, control para selects
 		formState: { errors },
 	} = useFormContext<TripStepType>();
 
 	return (
 		<>
-			<div className='FormFieldsContainer w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 items-start'>
+			<div className='FormFieldsContainer w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 items-start'>
 				<div className='RadioGroupContainer flex flex-col'>
 					<Controller
 						name='trip_has_reincidence'
@@ -35,7 +37,7 @@ export default function TripStep() {
 									aria-invalid={!!errors.trip_has_reincidence}
 									aria-required
 								>
-									Já viajou antes para cá?
+									{t('trip_has_reincidence.form_label')}
 								</FormLabel>
 								<FormControl>
 									<RadioGroup
@@ -49,7 +51,7 @@ export default function TripStep() {
 												<RadioGroupItem className='size-5' value='true' />
 											</FormControl>
 											<FormLabel className='font-normal text-base'>
-												Sim
+												{t('trip_has_reincidence.options.radio_true')}
 											</FormLabel>
 										</FormItem>
 										<FormItem className='flex items-center'>
@@ -57,7 +59,7 @@ export default function TripStep() {
 												<RadioGroupItem className='size-5' value='false' />
 											</FormControl>
 											<FormLabel className='font-normal text-base'>
-												Não
+												{t('trip_has_reincidence.options.radio_false')}
 											</FormLabel>
 										</FormItem>
 									</RadioGroup>
@@ -78,7 +80,7 @@ export default function TripStep() {
 							htmlFor='trip_reincidence'
 							aria-invalid={!!errors.trip_reincidence}
 						>
-							Quantas vezes já visitou a Ibiapaba?
+							{t('trip_reincidence.form_label')}
 						</FormLabel>
 
 						<Controller
@@ -105,7 +107,7 @@ export default function TripStep() {
 
 			<Separator className='opacity-70' />
 
-			<div className='FormFieldsContainer w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 items-start'>
+			<div className='FormFieldsContainer w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 items-start'>
 				<div className='RadioGroupContainer flex flex-col'>
 					<Controller
 						name='trip_know_ibiapaba_mirantes'
@@ -117,7 +119,7 @@ export default function TripStep() {
 									aria-invalid={!!errors.trip_know_ibiapaba_mirantes}
 									aria-required
 								>
-									Conhece a Rota Mirantes da Ibiapaba?
+									{t('trip_know_ibiapaba_mirantes.form_label')}
 								</FormLabel>
 								<FormControl>
 									<RadioGroup
@@ -131,7 +133,7 @@ export default function TripStep() {
 												<RadioGroupItem className='size-5' value='true' />
 											</FormControl>
 											<FormLabel className='font-normal text-base'>
-												Sim
+												{t('trip_know_ibiapaba_mirantes.options.radio_true')}
 											</FormLabel>
 										</FormItem>
 										<FormItem className='flex items-center'>
@@ -139,7 +141,7 @@ export default function TripStep() {
 												<RadioGroupItem className='size-5' value='false' />
 											</FormControl>
 											<FormLabel className='font-normal text-base'>
-												Não
+												{t('trip_know_ibiapaba_mirantes.options.radio_false')}
 											</FormLabel>
 										</FormItem>
 									</RadioGroup>
@@ -160,7 +162,7 @@ export default function TripStep() {
 							htmlFor='trip_how_know_ibiapaba_mirantes'
 							aria-invalid={!!errors.trip_how_know_ibiapaba_mirantes}
 						>
-							Por onde conheceu a rota?
+							{t('trip_how_know_ibiapaba_mirantes.form_label')}
 						</FormLabel>
 
 						<Controller
@@ -198,7 +200,7 @@ export default function TripStep() {
 						aria-invalid={!!errors.trip_reasons}
 						aria-required
 					>
-						Motivo(s) da viagem
+						{t('trip_reasons.form_label')}
 					</FormLabel>
 
 					<Controller
@@ -226,7 +228,7 @@ export default function TripStep() {
 						aria-invalid={!!errors.trip_stay_time}
 						aria-required
 					>
-						Tempo de permanência
+						{t('trip_stay_time.form_label')}
 					</FormLabel>
 
 					<Controller
@@ -252,7 +254,7 @@ export default function TripStep() {
 						aria-invalid={!!errors.trip_vehicles}
 						aria-required
 					>
-						Veículo(s) utilizado(s)
+						{t('trip_vehicles.form_label')}
 					</FormLabel>
 
 					<Controller
@@ -284,7 +286,7 @@ export default function TripStep() {
 						aria-invalid={!!errors.trip_average_diary_expense}
 						aria-required
 					>
-						Quanto gastou ou pretende gastar em média por dia
+						{t('trip_average_diary_expense.form_label')}
 					</FormLabel>
 
 					<Controller
@@ -312,7 +314,7 @@ export default function TripStep() {
 						aria-invalid={!!errors.trip_hosting_types}
 						aria-required
 					>
-						Tipo de hospedagem
+						{t('trip_hosting_types.form_label')}
 					</FormLabel>
 
 					<Controller

--- a/src/forms/ExampleForm/steps/step4-activities.tsx
+++ b/src/forms/ExampleForm/steps/step4-activities.tsx
@@ -1,16 +1,18 @@
 import { FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Controller, useFormContext } from 'react-hook-form';
 import {
-	activitiesStepSelectOptions,
 	ActivitiesStepType,
+	getActivitiesStepSelectOptions,
 } from '../schemas/step4-activities-schema';
 import { SelectWithSearch } from '@/components/ui/select-with-search';
 import { Separator } from '@/components/ui/separator';
+import { useTranslations } from 'next-intl';
 
 export default function ActivitiesStep() {
+	const t = useTranslations('forms.ExampleForm.steps.4.fields');
+	const activitiesStepSelectOptions = getActivitiesStepSelectOptions(t);
 	const {
 		control,
-		// register, -> register para inputs, control para selects
 		formState: { errors },
 	} = useFormContext<ActivitiesStepType>();
 
@@ -24,7 +26,7 @@ export default function ActivitiesStep() {
 						aria-invalid={!!errors.activities_places_visited}
 						aria-required
 					>
-						Lugares que deseja visitar ou visitou
+						{t('activities_places_visited.form_label')}
 					</FormLabel>
 
 					<Controller
@@ -52,7 +54,7 @@ export default function ActivitiesStep() {
 						htmlFor='activities_events_visited'
 						aria-invalid={!!errors.activities_events_visited}
 					>
-						Tipos de eventos que deseja visitar ou visitou
+						{t('activities_events_visited.form_label')}
 					</FormLabel>
 
 					<Controller
@@ -85,7 +87,7 @@ export default function ActivitiesStep() {
 						htmlFor='activities_events_visited'
 						aria-invalid={!!errors.activities_events_visited}
 					>
-						Aplicativos usados no planejamento e durante a viagem
+						{t('activities_used_apps.form_label')}
 					</FormLabel>
 
 					<Controller

--- a/src/forms/ExampleForm/steps/step5-evaluation.tsx
+++ b/src/forms/ExampleForm/steps/step5-evaluation.tsx
@@ -2,14 +2,17 @@ import { FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { SelectWithSearch } from '@/components/ui/select-with-search';
 import { Controller, useFormContext } from 'react-hook-form';
 import {
-	evaluationStepSelectOptions,
 	EvaluationStepType,
+	getEvaluationStepSelectOptions,
 } from '../schemas/step5-evaluation-schema';
 import NpsSlider from '@/components/NpsSlider';
 import { Separator } from '@/components/ui/separator';
 import { Textarea } from '@/components/ui/textarea';
+import { useTranslations } from 'next-intl';
 
 export default function EvaluationStep() {
+	const t = useTranslations('forms.ExampleForm.steps.5.fields');
+	const evaluationStepSelectOptions = getEvaluationStepSelectOptions(t);
 	const {
 		control,
 		register,
@@ -25,7 +28,7 @@ export default function EvaluationStep() {
 						aria-invalid={!!errors.evaluation_expectation_rate}
 						aria-required
 					>
-						De 1 a 10, o quanto você recomendaria alguém visitar a Ibiapaba?
+						{t('evaluation_recommendation_rate.form_label')}
 					</FormLabel>
 
 					<Controller
@@ -52,7 +55,7 @@ export default function EvaluationStep() {
 						htmlFor='evaluation_dissatisfactions'
 						aria-invalid={!!errors.evaluation_dissatisfactions}
 					>
-						Quais aspectos menos gostou na visita?
+						{t('evaluation_dissatisfactions.form_label')}
 					</FormLabel>
 
 					<Controller
@@ -88,7 +91,7 @@ export default function EvaluationStep() {
 						aria-invalid={!!errors.evaluation_expectation_rate}
 						aria-required
 					>
-						Qual era seu nível de expectativa antes da visita?
+						{t('evaluation_expectation_rate.form_label')}
 					</FormLabel>
 
 					<Controller
@@ -116,7 +119,7 @@ export default function EvaluationStep() {
 						aria-invalid={!!errors.evaluation_satisfaction_rate}
 						aria-required
 					>
-						Qual foi o seu nível de satisfação após a visita?
+						{t('evaluation_satisfaction_rate.form_label')}
 					</FormLabel>
 
 					<Controller
@@ -144,7 +147,7 @@ export default function EvaluationStep() {
 						aria-invalid={!!errors.evaluation_return_intent_rate}
 						aria-required
 					>
-						O quanto você pretende retornar à Ibiapaba?
+						{t('evaluation_return_intent_rate.form_label')}
 					</FormLabel>
 
 					<Controller
@@ -175,15 +178,13 @@ export default function EvaluationStep() {
 						htmlFor='evaluation_open_opinion'
 						aria-invalid={!!errors.evaluation_open_opinion}
 					>
-						Você necessitou de algum serviço que não foi encontrado na Ibiapaba
-						ou tem alguma recomendação de melhoria da infraestrutura,
-						equipamentos e serviços turísticos?
+						{t('evaluation_open_opinion.form_label')}
 					</FormLabel>
 
 					<Textarea
 						id='evaluation_open_opinion'
 						{...register('evaluation_open_opinion')}
-						placeholder='Gostaríamos de ouvir sua opinião :)'
+						placeholder={t('evaluation_open_opinion.input_placeholder')}
 						aria-invalid={!!errors.evaluation_open_opinion}
 					/>
 

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,4 +1,8 @@
-export type Locale = (typeof locales)[number];
-
 export const locales = ['en', 'pt-BR', 'es'] as const;
+export type Locale = (typeof locales)[number];
+export const LocaleENUM = {
+	en: 'en',
+	ptBR: 'pt-BR',
+	es: 'es',
+} as const;
 export const defaultLocale: Locale = 'en';

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,0 +1,4 @@
+export type Locale = (typeof locales)[number];
+
+export const locales = ['en', 'pt-BR', 'es'] as const;
+export const defaultLocale: Locale = 'en';

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,0 +1,10 @@
+import { getRequestConfig } from 'next-intl/server';
+import { getUserLocale } from '../services/get-user-locale';
+
+export default getRequestConfig(async () => {
+	const locale = await getUserLocale();
+	return {
+		locale,
+		messages: (await import(`../../public/locales/${locale}.json`)).default,
+	};
+});

--- a/src/services/get-user-locale.ts
+++ b/src/services/get-user-locale.ts
@@ -1,0 +1,19 @@
+'use server';
+
+import { headers } from 'next/headers';
+import { Locale, defaultLocale } from '@/i18n/config';
+
+const HEADER_NAME = 'accept-language';
+
+export async function getUserLocale() {
+	const locale = (await headers()).get(HEADER_NAME)?.split(',')[0];
+
+	if (!locale) return defaultLocale;
+	if (locale.startsWith('pt')) return 'pt-BR';
+	if (locale.startsWith('en')) return 'en';
+	if (locale.startsWith('es')) return 'es';
+}
+
+export async function setUserLocale(locale: Locale) {
+	(await headers()).set(HEADER_NAME, locale);
+}

--- a/src/services/get-user-locale.ts
+++ b/src/services/get-user-locale.ts
@@ -1,19 +1,38 @@
 'use server';
 
-import { headers } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 import { Locale, defaultLocale } from '@/i18n/config';
 
 const HEADER_NAME = 'accept-language';
+const COOKIE_NAME = 'user-locale';
 
-export async function getUserLocale() {
-	const locale = (await headers()).get(HEADER_NAME)?.split(',')[0];
+export async function getUserLocale(): Promise<Locale> {
+	const cookieStore = await cookies();
+	const cookieLocale = cookieStore.get(COOKIE_NAME)?.value;
 
-	if (!locale) return defaultLocale;
-	if (locale.startsWith('pt')) return 'pt-BR';
-	if (locale.startsWith('en')) return 'en';
-	if (locale.startsWith('es')) return 'es';
+	if (cookieLocale && isValidLocale(cookieLocale)) {
+		return cookieLocale as Locale;
+	}
+
+	const headerLocale = (
+		(await headers()).get(HEADER_NAME)?.split(',')[0] || ''
+	).toLowerCase();
+
+	if (headerLocale.startsWith('pt')) return 'pt-BR';
+	if (headerLocale.startsWith('en')) return 'en';
+	if (headerLocale.startsWith('es')) return 'es';
+
+	return defaultLocale;
 }
 
 export async function setUserLocale(locale: Locale) {
-	(await headers()).set(HEADER_NAME, locale);
+	const cookieStore = await cookies();
+	cookieStore.set(COOKIE_NAME, locale, {
+		path: '/',
+		maxAge: 60 * 60 * 24 * 365, // 1 year
+	});
+}
+
+function isValidLocale(locale: string): locale is Locale {
+	return ['en', 'pt-BR', 'es'].includes(locale);
 }


### PR DESCRIPTION
### 📝 Resumo da mudança
Adiciona feature de internacionalização para toda a aplicação, localizando em três linguagens: Português (Brasil), Inglês e Espanhol.

### 📌 Motivações

Garantir compreensão de turistas respondentes do formulário preliminar e futuros usuários do portal futuro

### ✅ Principais mudanças
- [X] Adição da biblioteca `next-intl` para coordenar uso de traduções na aplicação
- [X] Adição de arquivos `json` para localização específica de páginas e componentes para linguagens distintas
- [x] Detecção automática de linguagem do browser via header `accept-language` e definição de cookie `user-locale` para definição de linguagem
- [X] Schemas de formulário gerados dinamicamente para conter mensagens de erro e opções de seleção traduzidas
---

### 🚀 Como testar
1. Clone a aplicação localmente
2. Execute conforme as instruções no README principal
3. Troque as linguagens no cabeçalho da(s) página(s)

---

### 📷 Evidências

* Componente que troca linguagem através de requisição para api interna em `/api/set-locale`, atualizando cookie
![image](https://github.com/user-attachments/assets/bb6d9c37-ceb9-4124-8845-caf6e412e446)

* Etapa do formulário integralmente traduzida em Espanhol
![image](https://github.com/user-attachments/assets/ae7d1ed3-fe59-4326-a954-a0bcd67486e7)