### PR TITLE
Hotfix: rename fallback base URL for API in handleLocaleChange

### DIFF
--- a/src/services/locale/handle-locale-change.ts
+++ b/src/services/locale/handle-locale-change.ts
@@ -2,7 +2,7 @@ import { Locale } from 'next-intl';
 
 export async function handleLocaleChange(locale: Locale) {
 	try {
-		const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || '/api';
+		const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || '/otib/api';
 		const url = baseUrl.startsWith('/') ? baseUrl : `/${baseUrl}`;
 
 		const response = await fetch(`${url}/set-locale`, {

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -1,4 +1,4 @@
-import { IBM_Plex_Mono, IBM_Plex_Sans, Inter } from 'next/font/google';
+import { /* IBM_Plex_Mono, */ IBM_Plex_Sans, Inter } from 'next/font/google';
 
 export const inter = Inter({
 	weight: '400',
@@ -15,9 +15,9 @@ export const ibmPlexSans = IBM_Plex_Sans({
 	variable: '--font-ibm-plex-sans',
 });
 
-export const ibmPlexMono = IBM_Plex_Mono({
-	weight: '500',
-	fallback: ['mono'],
-	subsets: ['latin'],
-	variable: '--font-ibm-plex-mono',
-});
+// export const ibmPlexMono = IBM_Plex_Mono({
+// 	weight: '500',
+// 	fallback: ['mono'],
+// 	subsets: ['latin'],
+// 	variable: '--font-ibm-plex-mono',
+// });


### PR DESCRIPTION
## 🐛 Correções de Bugs

- [X] Fallback de URL base corrigido para `/otib/api` em handleLocaleChange